### PR TITLE
[after int tests PR] Notes with tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm:
+  - 2.5.3
+services:
+  - redis-server
+script:
+  - bundle install
+  - bundle exec "rspec spec tests/"

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,7 @@ gem 'redcarpet'
 gem 'builder'
 gem 'nokogiri'
 gem 'activesupport'
+
+group :test do
+  gem 'rspec'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
     builder (3.2.3)
     concurrent-ruby (1.1.3)
     daemons (1.2.6)
+    diff-lcs (1.3)
     eventmachine (1.2.7)
     haml (5.0.4)
       temple (>= 0.8.0)
@@ -27,6 +28,19 @@ GEM
       rack
     redcarpet (3.4.0)
     redis (4.0.3)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.1)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.2)
     sinatra (2.0.4)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -60,6 +74,7 @@ DEPENDENCIES
   nokogiri
   redcarpet
   redis
+  rspec
   sinatra
   sinatra-contrib
   thin

--- a/lib/faexport.rb
+++ b/lib/faexport.rb
@@ -55,7 +55,7 @@ module FAExport
     USER_REGEX = /((?:[a-zA-Z0-9\-_~.]|%5B|%5D|%60)+)/
     ID_REGEX = /([0-9]+)/
     COOKIE_REGEX = /^b=[a-z0-9\-]+; a=[a-z0-9\-]+$/
-    NOTE_FOLDER_REGEX = /(inbox|outbox)/
+    NOTE_FOLDER_REGEX = /(inbox|outbox|unread|archive|trash|high|medium|low)/
 
     def initialize(app, config = {})
       FAExport.config = config.with_indifferent_access

--- a/lib/faexport.rb
+++ b/lib/faexport.rb
@@ -55,6 +55,7 @@ module FAExport
     USER_REGEX = /((?:[a-zA-Z0-9\-_~.]|%5B|%5D|%60)+)/
     ID_REGEX = /([0-9]+)/
     COOKIE_REGEX = /^b=[a-z0-9\-]+; a=[a-z0-9\-]+$/
+    NOTE_FOLDER_REGEX = /(inbox|outbox)/
 
     def initialize(app, config = {})
       FAExport.config = config.with_indifferent_access
@@ -612,6 +613,50 @@ module FAExport
             builder :post
           end
           builder :feed
+        end
+      end
+    end
+
+    # GET /notes/{folder}.json
+    # GET /notes/{folder}.xml
+    # GET /notes/{folder}.rss
+    get %r{/notes/#{NOTE_FOLDER_REGEX}\.(json|xml|rss)} do |folder, type|
+      ensure_login!
+      cache("notes/#{folder}:#{@user_cookie}.#{type}") do
+        case type
+        when 'json'
+          JSON.pretty_generate @fa.notes(folder)
+        when 'xml'
+          @fa.notes(folder).to_xml(root: 'results', skip_types: true)
+        when 'rss'
+          results = @fa.notes(folder)
+          @name = "Notes in folder: #{folder}"
+          @info = @name
+          @link = "https://www.furaffinity.net/msg/pms/"
+          @posts = results.map do |note|
+            @post = {
+                title: note[:subject],
+                link: note[:link],
+                posted: note[:posted]
+            }
+            @description = "A new note has been received, from <a href=\"#{note[:profile]}\">#{note[:name]}</a>, the subject is \"<a href=\"#{note[:link]}\">#{note[:subject]}</a>\"."
+            builder :post
+          end
+          builder :feed
+        end
+      end
+    end
+
+    # GET /note/{id}.json
+    # GET /note/{id}.xml
+    get %r{/note/#{ID_REGEX}\.(json|xml)} do |id, type|
+      ensure_login!
+      cache("note/#{id}:#{@user_cookie}.#{type}") do
+        case type
+        when 'json'
+          JSON.pretty_generate @fa.note(id)
+        when 'xml'
+          @fa.note(id).to_xml(root: 'note', skip_types: true)
         end
       end
     end

--- a/lib/faexport.rb
+++ b/lib/faexport.rb
@@ -137,6 +137,8 @@ module FAExport
       end
     end
 
+    # GET /home.json
+    # GET /home.xml
     get %r{/home\.(json|xml)} do |type|
       set_content_type(type)
       cache("home:#{type}") do
@@ -375,19 +377,19 @@ module FAExport
       cache("search_results:#{params.to_s}.#{type}") do
         case type
         when 'json'
-          results, _ = @fa.search(params)
+          results = @fa.search(params)
           results = results.map{|result| result[:id]} unless full
           JSON.pretty_generate results
         when 'xml'
-          results, _ = @fa.search(params)
+          results = @fa.search(params)
           results = results.map{|result| result[:id]} unless full
           results.to_xml(root: 'results', skip_types: true)
         when 'rss'
-          results, uri = @fa.search(params)
+          results = @fa.search(params)
 
           @name = params['q']
           @info = "Search for '#{params['q']}'"
-          @link = uri.to_s
+          @link = "https://www.furaffinity.net/search/?q=#{params['q']}"
           @posts = results.take(FAExport.config[:rss_limit]).map do |sub|
             cache "submission:#{sub[:id]}.rss" do
               @post = @fa.submission(sub[:id])

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -714,6 +714,63 @@ class Furaffinity
     }
   end
 
+  def note(id)
+    html = fetch("msg/pms/1/#{id}/")
+    current_user = get_current_user(html)
+    note_table = html.at_css(".note-view-container table.maintable table.maintable")
+    # date = pick_date(html.at_css('td.cat .journal-title-box .popup_date'))
+    # profile_url = html.at_css('td.cat .journal-title-box a')['href'][1..-1]
+    # journal_header = html.at_css('.journal-header').children[0..-3].to_s.strip unless html.at_css('.journal-header').nil?
+    # journal_footer = html.at_css('.journal-footer').children[2..-1].to_s.strip unless html.at_css('.journal-footer').nil?
+    #
+    # {
+    #     title: html.at_css('td.cat b').content.gsub(/\A[[:space:]]+|[[:space:]]+\z/, ''),
+    #     description: html.at_css('td.alt1 div.no_overflow').children.to_s.strip,
+    #     journal_header: journal_header,
+    #     journal_body: html.at_css('.journal-body').children.to_s.strip,
+    #     journal_footer: journal_footer,
+    #     name: html.at_css('td.cat .journal-title-box a').content,
+    #     profile: fa_url(profile_url),
+    #     profile_name: last_path(profile_url),
+    #     avatar: "https:#{html.at_css("img.avatar")['src']}",
+    #     link: fa_url("journal/#{id}/"),
+    #     posted: date,
+    #     posted_at: to_iso8601(date)
+    # }
+    note_header = note_table.at_css("td.head")
+    note_from = note_header.css("em")[1].at_css("a")
+    note_to = note_header.css("em")[2].at_css("a")
+    is_inbound = current_user[:profile_name] == last_path(note_to['href'])
+    profile = is_inbound ? note_from : note_to
+    date = pick_date(note_table.at_css("span.popup_date"))
+    description = note_table.at_css("td.text")
+    desc_split = description.inner_html.split("—————————")
+    {
+        note_id: id,
+        subject: note_header.at_css("em.title").content,
+        is_inbound: is_inbound,
+        name: profile.content,
+        profile: fa_url(profile['href'][1..-1]),
+        profile_name: last_path(profile['href']),
+        posted: date,
+        posted_at: to_iso8601(date),
+        avatar: "https#{note_table.at_css("img.avatar")['src']}",
+        description: description.inner_html.strip,
+        description_body: html_strip(desc_split.first.strip),
+        preceeding_notes: desc_split[1..-1].map do |note|
+          note_html = Nokogiri::HTML(note)
+          profile = note_html.at_css("a.linkusername")
+          {
+              name: profile.content.to_s,
+              profile: fa_url(profile['href'][1..-1]),
+              profile_name: last_path(profile['href']),
+              description: note,
+              description_body: html_strip(note.to_s.split("</a>:")[1..-1].join("</a>:"))
+          }
+        end
+    }
+  end
+
   def fa_url(path)
     if path.to_s.start_with? "/"
       path = path[1..-1]
@@ -724,6 +781,10 @@ class Furaffinity
 private
   def fa_address
     "https://#{safe_for_work ? 'sfw' : 'www'}.furaffinity.net"
+  end
+
+  def html_strip(html_s)
+    html_s.gsub(/^(<br ?\/?>|\\r|\\n|\s)+/, "").gsub(/(<br ?\/?>|\\r|\\n|\s)+$/,"")
   end
 
   def last_path(path)

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -796,9 +796,13 @@ class Furaffinity
   end
 
   def note(id)
-    html = fetch("msg/pms/1/#{id}/")
-    current_user = get_current_user(html)
+    url = "msg/pms/1/#{id}/"
+    html = fetch(url)
+    current_user = get_current_user(html, url)
     note_table = html.at_css(".note-view-container table.maintable table.maintable")
+    if note_table.nil?
+      raise FASystemError.new(url)
+    end
     note_header = note_table.at_css("td.head")
     note_from = note_header.css("em")[1].at_css("a")
     note_to = note_header.css("em")[2].at_css("a")
@@ -819,12 +823,12 @@ class Furaffinity
         avatar: "https#{note_table.at_css("img.avatar")['src']}",
         description: description.inner_html.strip,
         description_body: html_strip(desc_split.first.strip),
-        preceeding_notes: desc_split[1..-1].map do |note|
+        preceding_notes: desc_split[1..-1].map do |note|
           note_html = Nokogiri::HTML(note)
           profile = note_html.at_css("a.linkusername")
           {
               name: profile.content.to_s,
-              profile: fa_url(profile['href'][1..-1]),
+              profile: fa_url(profile['href'][1..-1]+"/"),
               profile_name: last_path(profile['href']),
               description: note,
               description_body: html_strip(note.to_s.split("</a>:")[1..-1].join("</a>:"))

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -782,10 +782,10 @@ class Furaffinity
         end
       end
       {
-          note_id: note.at_css("input")['value'],
+          note_id: note.at_css("input")['value'].to_i,
           subject: subject.at_css("a.notelink").content,
           is_inbound: is_inbound,
-          is_read: subject.at_css("img.unread").nil?,
+          is_read: subject.at_css("a.notelink.note-unread").nil?,
           name: profile.content,
           profile: fa_url(profile['href'][1..-1]),
           profile_name: last_path(profile['href']),
@@ -926,7 +926,7 @@ private
   def fetch(path, extra_cookie = nil)
     url = fa_url(path)
     raw = @cache.add("url:#{url}:#{@login_cookie}:#{extra_cookie}") do
-      open(url, 'User-Agent' => USER_AGENT, 'Cookie' => "@login_cookie;#{extra_cookie}") do |response|
+      open(url, 'User-Agent' => USER_AGENT, 'Cookie' => "#{@login_cookie};#{extra_cookie}") do |response|
         if response.status[0] != '200'
           raise FAStatusError.new(url, response.status.join(' '))
         end

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -718,25 +718,6 @@ class Furaffinity
     html = fetch("msg/pms/1/#{id}/")
     current_user = get_current_user(html)
     note_table = html.at_css(".note-view-container table.maintable table.maintable")
-    # date = pick_date(html.at_css('td.cat .journal-title-box .popup_date'))
-    # profile_url = html.at_css('td.cat .journal-title-box a')['href'][1..-1]
-    # journal_header = html.at_css('.journal-header').children[0..-3].to_s.strip unless html.at_css('.journal-header').nil?
-    # journal_footer = html.at_css('.journal-footer').children[2..-1].to_s.strip unless html.at_css('.journal-footer').nil?
-    #
-    # {
-    #     title: html.at_css('td.cat b').content.gsub(/\A[[:space:]]+|[[:space:]]+\z/, ''),
-    #     description: html.at_css('td.alt1 div.no_overflow').children.to_s.strip,
-    #     journal_header: journal_header,
-    #     journal_body: html.at_css('.journal-body').children.to_s.strip,
-    #     journal_footer: journal_footer,
-    #     name: html.at_css('td.cat .journal-title-box a').content,
-    #     profile: fa_url(profile_url),
-    #     profile_name: last_path(profile_url),
-    #     avatar: "https:#{html.at_css("img.avatar")['src']}",
-    #     link: fa_url("journal/#{id}/"),
-    #     posted: date,
-    #     posted_at: to_iso8601(date)
-    # }
     note_header = note_table.at_css("td.head")
     note_from = note_header.css("em")[1].at_css("a")
     note_to = note_header.css("em")[2].at_css("a")

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -724,9 +724,38 @@ class Furaffinity
         high: "high_prio",
         medium: "medium_prio",
         low: "low_prio"
-    }[folder]
+    }[folder.to_sym]
     html = fetch("msg/pms/", "folder=#{note_cookie}")
-    # TODO: parse
+    notes_table = html.at_css("table#notes-list")
+    notes_table.css("tr.note").map do |note|
+      subject = note.at_css("td.subject")
+      profile_from = note.at_css("td.col-from")
+      profile_to = note.at_css("td.col-to")
+      date = pick_date(note.at_css("span.popup_date"))
+      if profile_to.nil?
+        is_inbound = true
+        profile = profile_from.at_css("a")
+      else
+        if profile_from.nil?
+          is_inbound = false
+          profile = profile_to.at_css("a")
+        else
+          is_inbound = profile_to.content.strip == "me"
+          profile = is_inbound ? profile_from.at_css("a") : profile_to.at_css("a")
+        end
+      end
+      {
+          note_id: note.at_css("input")['value'],
+          subject: subject.at_css("a.notelink").content,
+          is_inbound: is_inbound,
+          is_read: subject.at_css("img.unread").nil?,
+          name: profile.content,
+          profile: fa_url(profile['href'][1..-1]),
+          profile_name: last_path(profile['href']),
+          posted: date,
+          posted_at: to_iso8601(date)
+      }
+    end
   end
 
   def note(id)

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -714,6 +714,21 @@ class Furaffinity
     }
   end
 
+  def notes(folder)
+    note_cookie = {
+        inbox: "inbox",
+        outbox: "outbox",
+        unread: "unread",
+        archive: "archive",
+        trash: "trash",
+        high: "high_prio",
+        medium: "medium_prio",
+        low: "low_prio"
+    }[folder]
+    html = fetch("msg/pms/", "folder=#{note_cookie}")
+    # TODO: parse
+  end
+
   def note(id)
     html = fetch("msg/pms/1/#{id}/")
     current_user = get_current_user(html)
@@ -842,10 +857,10 @@ private
     CGI::escape(name)
   end
 
-  def fetch(path)
+  def fetch(path, extra_cookie = nil)
     url = fa_url(path)
-    raw = @cache.add("url:#{url}") do
-      open(url, 'User-Agent' => USER_AGENT, 'Cookie' => @login_cookie) do |response|
+    raw = @cache.add("url:#{url}:#{extra_cookie}") do
+      open(url, 'User-Agent' => USER_AGENT, 'Cookie' => "#{@login_cookie};#{extra_cookie}") do |response|
         if response.status[0] != '200'
           raise FAStatusError.new(url, response.status.join(' '))
         end

--- a/lib/faexport/views/docs.md
+++ b/lib/faexport/views/docs.md
@@ -812,6 +812,7 @@ Lists the notes in a specified folder. Specified folders can be `inbox`, `outbox
   {
     "note_id": 123,
     "subject": "No subject",
+    "is_inbound": true,
     "is_read": false,
     "name": "John Oliver",
     "profile_name": "https://furaffinity.net/user/john_oliver/",

--- a/lib/faexport/views/docs.md
+++ b/lib/faexport/views/docs.md
@@ -17,7 +17,7 @@ document.cookie.split('; ').filter(function(x){return/^[ab]=/.test(x)}).sort().r
 
 The output should look something like this:
 
-~~~javascript
+~~~
 "b=3a485360-d203-4a38-97e8-4ff7cdfa244c; a=b1b985c4-d73e-492a-a830-ad238a3693ef"
 ~~~
 
@@ -377,14 +377,14 @@ If you want more information, pass `?full=1` to retrieve more fields.
 
 Gets the the first few submissions from the specified folder.
 Options for `{folder}` are `gallery`, `scraps` and `favorites`.
-By default, the first 60 submissions are returned.
+By default, the first 72 submissions are returned.
 
-If this is `gallery` or `scraps`, you can pass a parameter `?page=2` to load more.
+If this is `gallery` or `scraps`, you can pass a parameter `?page=2` to load more
 
 **BREAKING CHANGE**
 
 Due to FA changing the way it handles pagination on favorites using `page` will no longer work.
-Instead, all favorites all now come with a `fav_id` field (assuing `?full=1` is used) that can be used with `next` and `prev`.
+Instead, all favorites all now come with a `fav_id` field (assuming `?full=1` is used) that can be used with `next` and `prev`.
 For instance if the last favorite fetched has an `fav_id` of `29980`, we can set `?next=29980` to
 load the next set of favorites that come after it.
 Likewise we can also use `?prev=29980` to load the set of favorites directly before it.
@@ -399,7 +399,7 @@ By default, this only returns the id of each submission.
   "11157906",
   "10796676",
   <snip>
-}
+]
 ~~~
 
 If you want more information, pass `?full=1` to retrieve more fields.
@@ -432,7 +432,7 @@ If you want more information, pass `?full=1` to retrieve more fields.
     "name": "Fender",
     "profile": "http://www.furaffinity.net/user/fender/",
     "profile_name": "fender"
-  }
+  },
   <snip>
 ]
 ~~~
@@ -520,7 +520,7 @@ Retrieves information about the journal with the specified id.
 
 ### GET /submission/*{id}*/comments <br/> GET /journal/*{id}*/comments
 
-Retrivies a list of comments made on the submission or journal with the specified id.
+Retrieves a list of comments made on the submission or journal with the specified id.
 
 *Formats:* `json`, `xml`
 
@@ -534,9 +534,10 @@ Retrivies a list of comments made on the submission or journal with the specifie
     "avatar": "http://a.facdn.net/1424258659/anotherartist.gif",
     "posted": "March 2nd, 2015 02:30 AM",
     "posted_at": "2015-03-02T02:30:00Z",
-    "text": "Wow, I love the way you do light and shadow."
+    "text": "Wow, I love the way you do light and shadow.",
     "reply_to": "",
-    "reply_level": 0
+    "reply_level": 0,
+    "is_deleted": false
   },
   {
     "id": "252377",
@@ -546,43 +547,46 @@ Retrivies a list of comments made on the submission or journal with the specifie
     "avatar": "http://a.facdn.net/1424258659/annoyingsalamander.gif",
     "posted": "March 1st, 2015 03:16 PM",
     "posted_at": "2015-03-01T15:16:00Z",
-    "text": "This drawing sucks."
+    "text": "This drawing sucks.",
     "reply_to": "260397",
-    "reply_level": 1
+    "reply_level": 1,
+    "is_deleted": false
   },
   {
     "id": "236568",
     "name": "afreshcat001",
     "profile": "http://www.furaffinity.net/user/afreshcat001/",
-    "profile": "afreshcat001",
+    "profile_name": "afreshcat001",
     "avatar": "http://a.facdn.net/1424258659/afreshcat001.gif",
     "posted": "February 28th, 2015 06:33 AM",
     "posted_at": "2015-02-28T06:33:00Z",
-    "text": "You stole my OC, REPORTED!"
+    "text": "You stole my OC, REPORTED!",
     "reply_to": "",
-    "reply_level": 0
+    "reply_level": 0,
+    "is_deleted": false
   },
   <snip>
 ]
 ~~~
 
-Any replies to a hidden comment will contain `"reply_to": "hidden"`.
 By default, hidden comments are not included.
 If you would like hidden comments to show up, pass `?include_hidden=1`.
 Hidden comments are displayed in the following format:
 
 ~~~json
 {
+  "id": "96269",
   "text": "Comment hidden by its author",
   "reply_to": "96267",
-  "reply_level": 9
+  "reply_level": 9,
+  "is_deleted": true
 }
 
 ~~~
 
 ### GET /search
 
-Perfoms a site wide search of Furaffinity.
+Performs a site wide search of Furaffinity.
 The following parameters can be provided:
 
 * **q**: Words to search for.
@@ -605,7 +609,7 @@ By default, this only returns the id of each submission.
   "11157906",
   "10796676",
   <snip>
-}
+]
 ~~~
 
 If you want more information, pass `&full=1` to retrieve more fields.
@@ -638,7 +642,7 @@ If you want more information, pass `&full=1` to retrieve more fields.
     "name": "Fender",
     "profile": "http://www.furaffinity.net/user/fender/",
     "profile_name": "fender"
-  }
+  },
   <snip>
 ]
 ~~~
@@ -653,7 +657,7 @@ Retrieves a list of new submission notifications.
 
 The way that FA handles paging in submission notifications is that you specify the ID of a submission in your notifications, and it will display that submission, and all the ones after it.
 You can specify the submission ID to start from with the `from=` parameter in the URL.
-Paging through submissions without overlap can be achieved by taking the last submission, adding 1 to the ID, and supplying that using the `from` parameter.
+Paging through submissions without overlap can be achieved by taking the last submission, subtracting 1 from the ID, and supplying that using the `from` parameter.
 
 ~~~json
 {
@@ -689,10 +693,10 @@ Paging through submissions without overlap can be achieved by taking the last su
       "name": "feve",
       "profile": "https://sfw.furaffinity.net/user/feve/",
       "profile_name": "feve"
-    }
+    },
     <snip>
   ]
-]
+}
 ~~~
 ### GET /notifications/others
 
@@ -703,14 +707,15 @@ Login cookie required.
 Retrieves a dictionary of all current (non-submission) notifications. RSS feeds are available for each individual notification type.
 
 While json and xml formats are available as a combined endpoint at /notifications/others, rss feeds are separated into 6 different endpoints:
-- /notifications/watches.rss
-- /notifications/submission_comments.rss
-- /notifications/journal_comments.rss
-- /notifications/shouts.rss
-- /notifications/favorites.rss
-- /notifications/journals.rss
+* /notifications/watches.rss
+* /notifications/submission_comments.rss
+* /notifications/journal_comments.rss
+* /notifications/shouts.rss
+* /notifications/favorites.rss
+* /notifications/journals.rss
 
 To include deleted notifications as well, pass `?include_deleted=1`.
+As deleted journal notifications are hidden on FA now, you cannot display these using the `include_deleted` parameter.
 
 ~~~json
 {
@@ -739,7 +744,8 @@ To include deleted notifications as well, pass `?include_deleted=1`.
       "profile_name": "scruffythedeer",
       "is_reply": true,
       "your_submission": false,
-      "submission_id": "#cid:138134657",
+      "their_submission": true,
+      "submission_id": "31400974",
       "title": "[CM] Willow Shafted (internal)",
       "posted": "on May 3rd, 2019 09:02 AM",
       "posted_at": "2019-05-03T09:02:00Z"
@@ -754,11 +760,13 @@ To include deleted notifications as well, pass `?include_deleted=1`.
       "profile_name": "jeevestheroo",
       "is_reply": true,
       "your_journal": false,
+      "their_journal": true,
       "journal_id": "9130470",
       "title": "Confuzzled 2019!! Say hello to me if you're going!",
       "posted": "on May 3rd, 2019 01:04 PM",
       "posted_at": "2019-05-03T13:04:00Z"
-    }
+    },
+    <snip>
   ],
   "new_shouts": [
     {

--- a/lib/faexport/views/docs.md
+++ b/lib/faexport/views/docs.md
@@ -852,7 +852,7 @@ Views a specific note.
   "posted_at": "2019-05-03T13:04:00Z",
   "description": "Not really. How are you?\n\n______<snip>",
   "description_body": "Not really. How are you?",
-  "preceeding_notes": [
+  "preceding_notes": [
     {
       "name": "Fender",
       "profile_name": "https://furaffinity.net/user/fender/",

--- a/lib/faexport/views/docs.md
+++ b/lib/faexport/views/docs.md
@@ -823,8 +823,8 @@ Lists the notes in a specified folder. Specified folders can be `inbox`, `outbox
     "is_inbound": true,
     "is_read": false,
     "name": "John Oliver",
-    "profile_name": "https://furaffinity.net/user/john_oliver/",
-    "profile": "john_oliver",
+    "profile": "https://furaffinity.net/user/john_oliver/",
+    "profile_name": "john_oliver",
     "posted": "on May 3rd, 2019 01:04 PM",
     "posted_at": "2019-05-03T13:04:00Z"
   },
@@ -846,8 +846,8 @@ Views a specific note.
   "subject": "Re: No subject",
   "is_inbound": true,
   "name": "John Oliver",
-  "profile_name": "https://furaffinity.net/user/john_oliver/",
-  "profile": "john_oliver",
+  "profile": "https://furaffinity.net/user/john_oliver/",
+  "profile_name": "john_oliver",
   "posted": "on May 3rd, 2019 01:04 PM",
   "posted_at": "2019-05-03T13:04:00Z",
   "description": "Not really. How are you?\n\n______<snip>",
@@ -855,14 +855,14 @@ Views a specific note.
   "preceding_notes": [
     {
       "name": "Fender",
-      "profile_name": "https://furaffinity.net/user/fender/",
-      "profile": "fender",
+      "profile": "https://furaffinity.net/user/fender/",
+      "profile_name": "fender",
       "description": "Hey, do u rp?"
     },
     {
       "name": "John Oliver",
-      "profile_name": "https://furaffinity.net/user/john_oliver/",
-      "profile": "john_oliver",
+      "profile": "https://furaffinity.net/user/john_oliver/",
+      "profile_name": "john_oliver",
       "description": "Hello there!"
     }
   ]

--- a/lib/faexport/views/docs.md
+++ b/lib/faexport/views/docs.md
@@ -810,9 +810,9 @@ Lists the notes in a specified folder. Specified folders can be `inbox`, `outbox
 ~~~json
 [
   {
-    "note_id": 0123,
+    "note_id": 123,
     "subject": "No subject",
-    "is_read": False,
+    "is_read": false,
     "name": "John Oliver",
     "profile_name": "https://furaffinity.net/user/john_oliver/",
     "profile": "john_oliver",
@@ -833,16 +833,16 @@ Views a specific note.
 
 ~~~json
 {
-  "note_id": 0123,
+  "note_id": 125,
   "subject": "Re: No subject",
-  "is_inbound": True,
+  "is_inbound": true,
   "name": "John Oliver",
   "profile_name": "https://furaffinity.net/user/john_oliver/",
   "profile": "john_oliver",
   "posted": "on May 3rd, 2019 01:04 PM",
   "posted_at": "2019-05-03T13:04:00Z",
   "description": "Not really. How are you?",
-  "earlier_notes": [
+  "preceeding_notes": [
     {
       "name": "Fender",
       "profile_name": "https://furaffinity.net/user/fender/",

--- a/lib/faexport/views/docs.md
+++ b/lib/faexport/views/docs.md
@@ -841,7 +841,8 @@ Views a specific note.
   "profile": "john_oliver",
   "posted": "on May 3rd, 2019 01:04 PM",
   "posted_at": "2019-05-03T13:04:00Z",
-  "description": "Not really. How are you?",
+  "description": "Not really. How are you?\n\n______<snip>",
+  "description_body": "Not really. How are you?",
   "preceeding_notes": [
     {
       "name": "Fender",

--- a/lib/faexport/views/docs.md
+++ b/lib/faexport/views/docs.md
@@ -823,7 +823,7 @@ Lists the notes in a specified folder. Specified folders can be `inbox`, `outbox
 ]
 ~~~
 
-### GET /notes/{id}
+### GET /note/{id}
 
 *Formats:* `json`, `xml`
 

--- a/lib/faexport/views/docs.md
+++ b/lib/faexport/views/docs.md
@@ -799,6 +799,66 @@ To include deleted notifications as well, pass `?include_deleted=1`.
 }
 ~~~
 
+### GET /notes/{folder}
+
+*Formats:* `json`, `xml`, `rss`
+
+Login cookie required.
+
+Lists the notes in a specified folder. Specified folders can be `inbox`, `outbox`, `unread`, `archive`, `trash`, `high`, `medium`, or `low`.
+
+~~~json
+[
+  {
+    "note_id": 0123,
+    "subject": "No subject",
+    "is_read": False,
+    "name": "John Oliver",
+    "profile_name": "https://furaffinity.net/user/john_oliver/",
+    "profile": "john_oliver",
+    "posted": "on May 3rd, 2019 01:04 PM",
+    "posted_at": "2019-05-03T13:04:00Z"
+  },
+  <snip>
+]
+~~~
+
+### GET /notes/{id}
+
+*Formats:* `json`, `xml`
+
+Login cookie required.
+
+Views a specific note.
+
+~~~json
+{
+  "note_id": 0123,
+  "subject": "Re: No subject",
+  "is_inbound": True,
+  "name": "John Oliver",
+  "profile_name": "https://furaffinity.net/user/john_oliver/",
+  "profile": "john_oliver",
+  "posted": "on May 3rd, 2019 01:04 PM",
+  "posted_at": "2019-05-03T13:04:00Z",
+  "description": "Not really. How are you?",
+  "earlier_notes": [
+    {
+      "name": "Fender",
+      "profile_name": "https://furaffinity.net/user/fender/",
+      "profile": "fender",
+      "description": "Hey, do u rp?"
+    },
+    {
+      "name": "John Oliver",
+      "profile_name": "https://furaffinity.net/user/john_oliver/",
+      "profile": "john_oliver",
+      "description": "Hello there!"
+    }
+  ]
+}
+~~~
+
 ### POST /journal
 
 *Formats:* `json`, `query`

--- a/lib/faexport/views/index.haml
+++ b/lib/faexport/views/index.haml
@@ -59,3 +59,16 @@
     %dd
       %a.resource{href: '#', target: '_blank', :'data-format' => "{base}/notifications/#{notification_type}.rss"}
       %br
+  %dt Notes (login cookie required)
+  %dd
+    - %w(json xml rss).map do |type|
+      - %w(inbox unread outbox high medium low archive trash).map do |folder|
+        %dd
+          %a.resource{href: '#', target: '_blank', :'data-format' => "{base}/notes/#{folder}.#{type}"}
+          %br
+  %dt Note view (login cookie required)
+  %dd
+    - %w(json xml).map do |type|
+      %dd
+        %a.resource{href: '#', target: '_blank', :'data-format' => "{base}/note/{id}.#{type}"}
+        %br

--- a/tests/integration/fa_parsing_spec.rb
+++ b/tests/integration/fa_parsing_spec.rb
@@ -2006,9 +2006,56 @@ describe 'FA parser' do
     end
 
     context 'individual notes' do
-      it 'can view a specific note'
-      it 'can view an outbound note'
-      it 'throws an error for an invalid note'
+      it 'can view a specific note' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        note = @fa.note(108710830)
+
+        expect(note[:note_id]).to be_instance_of Integer
+        expect(note[:note_id]).not_to be_blank
+        expect(note[:subject]).to be_instance_of String
+        expect(note[:subject]).not_to be_blank
+        expect(note[:is_inbound]).to eql(true)
+        expect(note[:profile]).not_to eql(TEST_USER_2)
+        check_profile_link(note)
+        check_date(note[:posted], note[:posted_at])
+        expect(note[:description]).to be_instance_of String
+        expect(note[:description]).not_to be_blank
+        expect(note[:description_body]).to be_instance_of String
+        expect(note[:description_body]).not_to be_blank
+        expect(note[:description]).to start_with(note[:description_body])
+        expect(note[:preceding_notes]).to be_instance_of Array
+        expect(note[:preceding_notes].length).to eql(0)
+      end
+
+      it 'correctly parses preceding notes' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        note = @fa.note(108710838)
+
+        expect(note[:note_id]).to be_instance_of Integer
+        expect(note[:note_id]).not_to be_blank
+        expect(note[:subject]).to be_instance_of String
+        expect(note[:subject]).not_to be_blank
+        expect(note[:is_inbound]).to be_in([true, false])
+        expect(note[:profile]).not_to eql(TEST_USER_2)
+        check_profile_link(note)
+        check_date(note[:posted], note[:posted_at])
+        expect(note[:description]).to be_instance_of String
+        expect(note[:description]).not_to be_blank
+        expect(note[:description_body]).to be_instance_of String
+        expect(note[:description_body]).not_to be_blank
+        expect(note[:description]).to start_with(note[:description_body])
+        expect(note[:preceding_notes]).to be_instance_of Array
+        expect(note[:preceding_notes].length).to eql(1)
+        expect(note[:preceding_notes][0][:description]).to be_instance_of String
+        expect(note[:preceding_notes][0][:description]).not_to be_blank
+        check_profile_link(note[:preceding_notes][0])
+        expect(note[:preceding_notes][0][:profile]).not_to eql(TEST_USER_2)
+      end
+
+      it 'throws an error for an invalid note' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        expect { @fa.note(108710839) }.to raise_error(FASystemError)
+      end
     end
   end
 

--- a/tests/integration/fa_parsing_spec.rb
+++ b/tests/integration/fa_parsing_spec.rb
@@ -1923,6 +1923,94 @@ describe 'FA parser' do
       expect(journal_resp[:url]).to eql("https://www.furaffinity.net/journal/#{journals[0][:id]}/")
     end
   end
+  
+  context 'when viewing notes' do
+    context 'folders' do
+      it 'can list inbox' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        notes = @fa.notes('inbox')
+
+        expect(notes).not_to be_empty
+
+        notes.map do |note|
+          expect(note[:note_id]).to be_instance_of Integer
+          expect(note[:note_id]).not_to be_blank
+          expect(note[:subject]).to be_instance_of String
+          expect(note[:subject]).not_to be_blank
+          expect(note[:is_inbound]).to eql(true)
+          expect(note[:is_read]).to be_in([true, false])
+          expect(note[:profile]).not_to eql(TEST_USER_2)
+          check_profile_link(note)
+          check_date(note[:posted], note[:posted_at])
+        end
+      end
+
+      it 'can list unread, which contains all unread notes from inbox' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        unread_notes = @fa.notes('unread')
+        inbox_notes = @fa.notes('inbox')
+
+        expect(unread_notes).not_to be_empty
+
+        unread_notes.map do |note|
+          expect(note[:is_read]).to eql(false)
+        end
+
+        unread_note_ids = unread_notes.map{|n| n[:note_id]}
+        inbox_note_ids = inbox_notes.select{|n| !n[:is_read]}.map{|n| n[:note_id]}
+
+        inbox_note_ids.map do |note_id|
+          expect(note_id).to be_in(unread_note_ids)
+        end
+      end
+
+      it 'can list outbox and handle unread outbound notes' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        notes = @fa.notes('outbox')
+
+        expect(notes).not_to be_empty
+
+        notes.map do |note|
+          expect(note[:note_id]).to be_instance_of Integer
+          expect(note[:note_id]).not_to be_blank
+          expect(note[:subject]).to be_instance_of String
+          expect(note[:subject]).not_to be_blank
+          expect(note[:is_inbound]).to eql(false)
+          expect(note[:is_read]).to be_in([true, false])
+          expect(note[:profile]).not_to eql(TEST_USER_2)
+          check_profile_link(note)
+          check_date(note[:posted], note[:posted_at])
+        end
+      end
+
+      it 'can list other folders' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        %w(high medium low archive trash).map do |folder|
+          notes = @fa.notes(folder)
+
+          expect(notes).not_to be_empty
+
+          notes.map do |note|
+            expect(note[:note_id]).to be_instance_of Integer
+            expect(note[:note_id]).not_to be_blank
+            expect(note[:subject]).to be_instance_of String
+            expect(note[:subject]).not_to be_blank
+            expect(note[:is_inbound]).to be_in([true, false])
+            expect(note[:is_read]).to be_in([true, false])
+            expect(note[:profile]).not_to eql(TEST_USER_2)
+            check_profile_link(note)
+            check_date(note[:posted], note[:posted_at])
+          end
+        end
+      end
+    end
+
+    context 'individual notes' do
+      it 'can view a specific note'
+      it 'can view an outbound note'
+      it 'throws an error for an invalid note'
+    end
+  end
 
   private
 
@@ -1958,7 +2046,7 @@ describe 'FA parser' do
 
   def check_date(date_string, iso_string)
     expect(date_string).not_to be_blank
-    expect(date_string).to match(/[A-Z][a-z]{2} [0-9]+[a-z]{2}, [0-9]{4} [0-9]{2}:[0-9]{2}/)
+    expect(date_string).to match(/[A-Z][a-z]{2} [0-9]+[a-z]{2}, [0-9]{4},? [0-9]{2}:[0-9]{2}/)
     expect(iso_string).not_to be_blank
     expect(iso_string).to eql(Time.parse(date_string + ' UTC').iso8601)
   end

--- a/tests/integration/fa_parsing_spec.rb
+++ b/tests/integration/fa_parsing_spec.rb
@@ -1,0 +1,1995 @@
+
+require './lib/faexport'
+
+require 'rspec'
+
+describe 'FA parser' do
+  COOKIE_DEFAULT = ENV['test_cookie']
+  TEST_USER = "fafeed"
+  TEST_USER_2 = "fafeed-2"
+  COOKIE_TEST_USER_2 = ENV['test_cookie_user_2']
+  TEST_USER_3 = "fafeed-3"
+  COOKIE_TEST_USER_3 = ENV['test_cookie_user_3']
+  # Specific test user cases
+  TEST_USER_NOT_EXIST = "fafeed-does-not-exist"
+  TEST_USER_WITH_BRACKETS = "l[i]s"
+  TEST_USER_OVER_200_WATCHERS = "fender"
+  TEST_USER_NO_WATCHERS = "fafeed-no-watchers"
+  TEST_USER_NO_JOURNALS = TEST_USER_NO_WATCHERS
+  TEST_USER_NO_SHOUTS = TEST_USER_NO_WATCHERS
+  TEST_USER_OVER_25_JOURNALS = TEST_USER_OVER_200_WATCHERS
+  TEST_USER_EMPTY_GALLERIES = TEST_USER_NO_WATCHERS
+  TEST_USER_2_PAGES_GALLERY = "rajii"
+  TEST_USER_HIDDEN_FAVS = TEST_USER_NO_WATCHERS
+  COOKIE_TEST_USER_HIDDEN_FAVS = ENV['test_cookie_hidden_favs']
+  TEST_USER_2_PAGES_FAVS = TEST_USER_2_PAGES_GALLERY
+  COOKIE_TEST_USER_NO_NOTIFICATIONS = COOKIE_TEST_USER_HIDDEN_FAVS
+  TEST_USER_JOURNAL_DUMP = TEST_USER_3
+  COOKIE_TEST_USER_JOURNAL_DUMP = COOKIE_TEST_USER_3
+
+  before do
+    config = File.exist?('settings-test.yml') ? YAML.load_file('settings-test.yml') : {}
+    @app = FAExport::Application.new(config).instance_variable_get(:@instance)
+    @fa = @app.instance_variable_get(:@fa)
+    @fa.login_cookie = COOKIE_DEFAULT
+  end
+
+  after do
+    # Do nothing
+  end
+
+  context 'when getting home page data' do
+    it 'has the 4 submission types' do
+      home = @fa.home
+      expect(home).to have_key(:artwork)
+      expect(home).to have_key(:writing)
+      expect(home).to have_key(:music)
+      expect(home).to have_key(:crafts)
+    end
+
+    it 'has valid submissions in all categories' do
+      home = @fa.home
+      keys = [:artwork, :writing, :music, :crafts]
+      home.map do |type, submissions|
+        expect(keys).to include(type)
+        expect(submissions).not_to be_empty
+        submissions.map(&method(:check_submission))
+      end
+    end
+
+    it 'only returns SFW results, if specified' do
+      @fa.safe_for_work = true
+      home = @fa.home
+      home.map do |_, submissions|
+        expect(submissions).not_to be_empty
+        submissions.map do |submission|
+          begin
+            full_submission = @fa.submission(submission[:id])
+            expect(full_submission[:rating]).to eql("General")
+          rescue FASystemError
+          end
+        end
+      end
+    end
+  end
+
+  context 'when getting user profile' do
+    it 'gives valid basic profile information' do
+      profile = @fa.user(TEST_USER)
+      # Check initial values
+      expect(profile[:id]).to be_nil
+      expect(profile[:name]).to eql(TEST_USER)
+      expect(profile[:profile]).to eql("https://www.furaffinity.net/user/#{TEST_USER}/")
+      expect(profile[:account_type]).to eql("Member")
+      check_avatar(profile[:avatar], TEST_USER)
+      expect(profile[:full_name]).not_to be_blank
+      expect(profile[:artist_type]).not_to be_blank
+      expect(profile[:user_title]).not_to be_blank
+      expect(profile[:user_title]).to eql(profile[:artist_type])
+      expect(profile[:current_mood]).to eql("accomplished")
+      # Check registration date
+      check_date(profile[:registered_since], profile[:registered_at])
+      # Check description
+      expect(profile[:artist_profile]).not_to be_blank
+      # Check numeric values
+      [:pageviews, :submissions, :comments_received, :comments_given, :journals, :favorites].each do |key|
+        expect(profile[key]).not_to be_blank
+        expect(profile[key]).to match(/^[0-9]+$/)
+      end
+    end
+
+    it 'fails when given a non-existent profile' do
+      expect { @fa.user(TEST_USER_NOT_EXIST) }.to raise_error(FASystemError)
+    end
+
+    it 'handles square brackets in profile name' do
+      profile_with_underscores = TEST_USER_WITH_BRACKETS
+      profile = @fa.user(profile_with_underscores)
+      expect(profile[:name].downcase).to eql(profile_with_underscores)
+    end
+
+    it 'shows featured submission' do
+      profile = @fa.user(TEST_USER_2)
+      expect(profile[:featured_submission]).not_to be_nil
+      check_submission profile[:featured_submission], true
+    end
+
+    it 'handles featured submission not being set' do
+      profile = @fa.user(TEST_USER)
+      expect(profile[:featured_submission]).to be_nil
+    end
+
+    it 'shows profile id' do
+      profile = @fa.user(TEST_USER_2)
+      expect(profile[:profile_id]).not_to be_nil
+      check_submission profile[:profile_id], true, true
+    end
+
+    it 'handles profile id not being set' do
+      profile = @fa.user(TEST_USER)
+      expect(profile[:profile_id]).to be_nil
+    end
+
+    it 'shows artist information' do
+      profile = @fa.user(TEST_USER_2)
+      expect(profile[:artist_information]).to be_instance_of Hash
+      expect(profile[:artist_information]).to have_key("Age")
+      expect(profile[:artist_information]["Age"]).to eql("70")
+      expect(profile[:artist_information]).to have_key("Species")
+      expect(profile[:artist_information]["Species"]).to eql("Robot")
+      expect(profile[:artist_information]).to have_key("Shell of Choice")
+      expect(profile[:artist_information]["Shell of Choice"]).to eql("irb")
+      expect(profile[:artist_information]).to have_key("Favorite Website")
+      expect(profile[:artist_information]["Favorite Website"]).to start_with("<a href=")
+      expect(profile[:artist_information]["Favorite Website"]).to include("https://www.ruby-lang.org")
+      expect(profile[:artist_information]["Favorite Website"]).to end_with("</a>")
+      expect(profile[:artist_information]).not_to have_key("Personal quote")
+    end
+
+    it 'handles blank artist information box' do
+      profile = @fa.user(TEST_USER)
+      expect(profile[:artist_information]).to be_instance_of Hash
+      expect(profile[:artist_information]).to be_empty
+    end
+
+    it 'shows contact information' do
+      profile = @fa.user(TEST_USER_2)
+      expect(profile[:contact_information]).to be_instance_of Array
+      expect(profile[:contact_information]).not_to be_empty
+      profile[:contact_information].each do |item|
+        expect(item[:title]).not_to be_blank
+        expect(item[:name]).not_to be_blank
+        expect(item).to have_key(:link)
+      end
+    end
+
+    it 'handles no contact information being set' do
+      profile = @fa.user(TEST_USER)
+      expect(profile[:profile_id]).to be_nil
+    end
+
+    it 'lists watchers of specified account' do
+      profile = @fa.user(TEST_USER)
+      expect(profile[:watchers]).to be_instance_of Hash
+      expect(profile[:watchers][:count]).to be_instance_of Integer
+      expect(profile[:watchers][:count]).to be > 0
+      expect(profile[:watchers][:recent]).to be_instance_of Array
+      expect(profile[:watchers][:recent].length).to be <= profile[:watchers][:count]
+      profile[:watchers][:recent].each do |item|
+        check_profile_link(item, true)
+      end
+      list = profile[:watchers][:recent].map do |item|
+        item[:profile_name]
+      end
+      expect(list).to include(TEST_USER_2)
+    end
+
+    it 'lists accounts watched by specified account' do
+      profile = @fa.user(TEST_USER)
+      expect(profile[:watching]).to be_instance_of Hash
+      expect(profile[:watching][:count]).to be_instance_of Integer
+      expect(profile[:watching][:count]).to be > 0
+      expect(profile[:watching][:recent]).to be_instance_of Array
+      expect(profile[:watching][:recent].length).to be <= profile[:watching][:count]
+      profile[:watching][:recent].each do |item|
+        check_profile_link(item, true)
+      end
+    end
+  end
+
+  context 'when listing user\'s watchers/watchees' do
+    [true, false].each do |is_watchers|
+      it 'displays a valid list of profile names' do
+        list = @fa.budlist(TEST_USER, 1, is_watchers)
+        expect(list).to be_instance_of Array
+        expect(list).not_to be_empty
+        list.each do |bud|
+          expect(bud).to be_instance_of String
+          expect(bud).not_to be_blank
+        end
+      end
+
+      it 'fails when given a non-existent profile' do
+        expect { @fa.budlist(TEST_USER_NOT_EXIST, 1, is_watchers) }.to raise_error(FASystemError)
+      end
+
+      it 'handles an empty watchers list' do
+        bud_list = @fa.budlist(TEST_USER_NO_WATCHERS, 1, is_watchers)
+        expect(bud_list).to be_instance_of Array
+        expect(bud_list).to be_empty
+      end
+    end
+
+    it 'displays a different list for is watching vs watched by' do
+      expect(@fa.budlist(TEST_USER, 1, true)).not_to eql(@fa.budlist(TEST_USER, 1, false))
+    end
+
+    it 'returns 200 users when more than one page exists' do
+      bud_list = @fa.budlist(TEST_USER_OVER_200_WATCHERS, 1, true)
+      expect(bud_list).to be_instance_of Array
+      expect(bud_list.length).to eql(200)
+      bud_list.each do |bud|
+        expect(bud).to be_instance_of String
+        expect(bud).not_to be_blank
+      end
+    end
+
+    it 'displays a second page, different than the first' do
+      bud_list1 = @fa.budlist(TEST_USER_OVER_200_WATCHERS, 1, true)
+      bud_list2 = @fa.budlist(TEST_USER_OVER_200_WATCHERS, 2, true)
+      expect(bud_list1).to be_instance_of Array
+      expect(bud_list1.length).to eql(200)
+      expect(bud_list2).to be_instance_of Array
+      expect(bud_list1).not_to eql(bud_list2)
+    end
+  end
+
+  context 'when listing a user\'s shouts' do
+    it 'displays a valid list of shouts' do
+      shouts = @fa.shouts(TEST_USER)
+      expect(shouts).to be_instance_of Array
+      shouts.each do |shout|
+        expect(shout[:id]).to match(/^shout-[0-9]+$/)
+        check_profile_link shout
+        check_avatar(shout[:avatar], shout[:profile_name])
+        check_date(shout[:posted], shout[:posted_at])
+        expect(shout[:text]).to be_instance_of String
+        expect(shout[:text]).not_to be_blank
+      end
+    end
+
+    it 'fails when given a non-existent user' do
+      expect { @fa.shouts(TEST_USER_NOT_EXIST) }.to raise_error(FASystemError)
+    end
+
+    it 'handles an empty shouts list' do
+      shouts = @fa.shouts(TEST_USER_NO_SHOUTS)
+      expect(shouts).to be_instance_of Array
+      expect(shouts).to be_empty
+    end
+  end
+
+  context 'when displaying commission information pages' do
+    it 'handles empty commission information' do
+      comms = @fa.commissions(TEST_USER)
+      expect(comms).to be_instance_of Array
+      expect(comms).to be_empty
+    end
+
+    it 'displays valid commission information data' do
+      comms = @fa.commissions(TEST_USER_2)
+      expect(comms).to be_instance_of Array
+      expect(comms).not_to be_empty
+      comms.each do |comm|
+        expect(comm[:title]).not_to be_empty
+        expect(comm[:price]).not_to be_empty
+        expect(comm[:description]).not_to be_empty
+        expect(comm[:submission]).to be_instance_of Hash
+        check_submission(comm[:submission], true, true)
+      end
+    end
+
+    it 'fails when given a non-existent user' do
+      expect { @fa.shouts(TEST_USER_NOT_EXIST) }.to raise_error(FASystemError)
+    end
+  end
+
+  context 'when listing a user\'s journals' do
+    it 'returns a list of journal IDs' do
+      journals = @fa.journals(TEST_USER, 1)
+      expect(journals).to be_instance_of Array
+      expect(journals).not_to be_empty
+      journals.each do |journal|
+        expect(journal[:id]).to match(/^[0-9]+$/)
+        expect(journal[:title]).not_to be_blank
+        expect(journal[:description]).not_to be_blank
+        expect(journal[:link]).to eql("https://www.furaffinity.net/journal/#{journal[:id]}/")
+        check_date(journal[:posted], journal[:posted_at])
+      end
+    end
+
+    it 'fails when given a non-existent user' do
+      expect { @fa.journals(TEST_USER_NOT_EXIST, 1) }.to raise_error(FASystemError)
+    end
+
+    it 'handles an empty journal listing' do
+      journals = @fa.journals(TEST_USER_NO_JOURNALS, 1)
+      expect(journals).to be_instance_of Array
+      expect(journals).to be_empty
+    end
+
+    it 'displays a second page, different than the first' do
+      journals1 = @fa.journals(TEST_USER_OVER_25_JOURNALS, 1)
+      journals2 = @fa.journals(TEST_USER_OVER_25_JOURNALS, 2)
+      expect(journals1).to be_instance_of Array
+      expect(journals1).not_to be_empty
+      expect(journals1.length).to be 25
+      expect(journals2).to be_instance_of Array
+      expect(journals2).not_to be_empty
+      expect(journals1).not_to eql(journals2)
+    end
+  end
+
+  context 'when viewing user galleries' do
+    %w(gallery scraps favorites).each do |folder|
+      it 'returns a list of valid submission' do
+        submissions = @fa.submissions(TEST_USER_2, folder, {})
+        expect(submissions).to be_instance_of Array
+        expect(submissions).not_to be_empty
+        submissions.each(&method(:check_submission))
+      end
+
+      it 'fails when given a non-existent user' do
+        expect { @fa.submissions(TEST_USER_NOT_EXIST, folder, {}) }.to raise_error(FASystemError)
+      end
+
+      it 'handles an empty gallery' do
+        submissions = @fa.submissions(TEST_USER_EMPTY_GALLERIES, folder, {})
+        expect(submissions).to be_instance_of Array
+        expect(submissions).to be_empty
+      end
+
+      it 'hides nsfw submissions if sfw is set' do
+        all_submissions = @fa.submissions(TEST_USER_2, folder, {})
+        @fa.safe_for_work = true
+        sfw_submissions = @fa.submissions(TEST_USER_2, folder, {})
+        expect(all_submissions).not_to eql(sfw_submissions)
+        expect(all_submissions.length).to be > sfw_submissions.length
+        sfw_submissions.each do |submission|
+          full_submission = @fa.submission(submission[:id])
+          expect(full_submission[:rating]).to eql("General")
+        end
+      end
+    end
+
+    context 'specifically gallery or scraps' do
+      %w(gallery scraps).each do |folder|
+        it 'handles paging correctly' do
+          gallery1 = @fa.submissions(TEST_USER_2_PAGES_GALLERY, folder, {})
+          gallery2 = @fa.submissions(TEST_USER_2_PAGES_GALLERY, folder, {page: 2})
+          expect(gallery1).to be_instance_of Array
+          expect(gallery2).to be_instance_of Array
+          expect(gallery1).not_to eql(gallery2)
+        end
+      end
+    end
+
+    context 'specifically favourites' do
+      it 'handles a hidden favourites list' do
+        favs = @fa.submissions(TEST_USER_HIDDEN_FAVS, "favorites", {})
+        expect(favs).to be_instance_of Array
+        expect(favs).to be_empty
+      end
+
+      it 'displays favourites of currently logged in user even if hidden' do
+        @fa.login_cookie = COOKIE_TEST_USER_HIDDEN_FAVS
+        expect(@fa.login_cookie).not_to be_nil
+        favs = @fa.submissions(TEST_USER_HIDDEN_FAVS, "favorites", {})
+        expect(favs).to be_instance_of Array
+        expect(favs).not_to be_empty
+      end
+
+      it 'uses next parameter to display submissions after a specified fav id' do
+        favs = @fa.submissions(TEST_USER_2_PAGES_FAVS, "favorites", {})
+        expect(favs).to be_instance_of Array
+        expect(favs.length).to be 72
+        # Get fav ID partially down
+        fav_id = favs[58][:fav_id]
+        fav_id_next = favs[59][:fav_id]
+        # Get favs after that ID
+        favs_next = @fa.submissions(TEST_USER_2_PAGES_FAVS, "favorites", {next: fav_id})
+        expect(favs_next.length).to be > (72 - 58)
+        expect(favs_next[0][:fav_id]).to eql(fav_id_next)
+        favs_next.each do |fav|
+          expect(fav[:fav_id]).to be < fav_id
+        end
+      end
+
+      it 'uses prev parameter to display only submissions before a specified fav id' do
+        favs1 = @fa.submissions(TEST_USER_2_PAGES_FAVS, "favorites", {})
+        expect(favs1).to be_instance_of Array
+        expect(favs1.length).to be 72
+        last_fav_id = favs1[71][:fav_id]
+        favs2 = @fa.submissions(TEST_USER_2_PAGES_FAVS, "favorites", {next: last_fav_id})
+        # Get fav ID partially through
+        overlap_fav_id = favs2[5][:fav_id]
+        favs_overlap = @fa.submissions(TEST_USER_2_PAGES_FAVS, "favorites", {prev: overlap_fav_id})
+        expect(favs1).to be_instance_of Array
+        expect(favs1.length).to be 72
+        favs_overlap.each do |fav|
+          expect(fav[:fav_id]).to be > overlap_fav_id
+        end
+      end
+    end
+  end
+
+  context 'when viewing a submission' do
+    it 'displays basic data correctly' do
+      sub_id = "16437648"
+      sub = @fa.submission(sub_id)
+      expect(sub[:title]).not_to be_blank
+      expect(sub[:description]).not_to be_blank
+      expect(sub[:description_body]).to eql(sub[:description])
+      check_profile_link(sub)
+      check_avatar(sub[:avatar], sub[:profile_name])
+      check_submission_link(sub[:link], sub_id)
+      check_date(sub[:posted], sub[:posted_at])
+      expect(sub[:download]).to match(/https:\/\/d.facdn.net\/art\/[^\/]+\/[0-9]+\/[0-9]+\..+\.png/)
+      # For an image submission, full == download
+      expect(sub[:full]).to eql(sub[:download])
+      check_thumbnail_link(sub[:thumbnail], sub_id)
+      # Info box
+      expect(sub[:category]).not_to be_blank
+      expect(sub[:theme]).not_to be_blank
+      expect(sub[:species]).not_to be_blank
+      expect(sub[:gender]).not_to be_blank
+      expect(sub[:favorites]).to match(/[0-9]+/)
+      expect(sub[:favorites].to_i).to be > 0
+      expect(sub[:comments]).to match(/[0-9]+/)
+      expect(sub[:comments].to_i).to be > 0
+      expect(sub[:views]).to match(/[0-9]+/)
+      expect(sub[:views].to_i).to be > 0
+      expect(sub[:resolution]).not_to be_blank
+      expect(sub[:rating]).not_to be_blank
+      expect(sub[:keywords]).to be_instance_of Array
+      expect(sub[:keywords]).to eql(%w(keyword1 keyword2 keyword3))
+    end
+
+    it 'fails when given non-existent submissions' do
+      expect { @fa.submission("16437650") }.to raise_error FASystemError
+    end
+
+    it 'parses keywords' do
+      sub_id = "16437648"
+      sub = @fa.submission(sub_id)
+      expect(sub[:keywords]).to be_instance_of Array
+      expect(sub[:keywords]).to eql(%w(keyword1 keyword2 keyword3))
+    end
+
+    it 'has identical description and description_body' do
+      sub = @fa.submission("32006442")
+      expect(sub[:description]).not_to be_blank
+      expect(sub[:description]).to eql(sub[:description_body])
+    end
+
+    it 'displays stories correctly' do
+      sub_id = "20438216"
+      sub = @fa.submission(sub_id)
+      expect(sub[:title]).not_to be_blank
+      expect(sub[:description]).not_to be_blank
+      expect(sub[:description_body]).to eql(sub[:description])
+      check_profile_link(sub)
+      check_avatar(sub[:avatar], sub[:profile_name])
+      check_submission_link(sub[:link], sub_id)
+      check_date(sub[:posted], sub[:posted_at])
+      expect(sub[:download]).to match(/https:\/\/d.facdn.net\/art\/[^\/]+\/stories\/[0-9]+\/[0-9]+\..+\.(rtf|doc|txt|docx|pdf)/)
+      # For a story submission, full != download
+      expect(sub[:full]).not_to be_blank
+      expect(sub[:full]).not_to eql(sub[:download])
+      check_thumbnail_link(sub[:thumbnail], sub_id)
+      # Info box
+      expect(sub[:category]).not_to be_blank
+      expect(sub[:theme]).not_to be_blank
+      expect(sub[:favorites]).to match(/[0-9]+/)
+      expect(sub[:favorites].to_i).to be >= 0
+      expect(sub[:comments]).to match(/[0-9]+/)
+      expect(sub[:comments].to_i).to be >= 0
+      expect(sub[:views]).to match(/[0-9]+/)
+      expect(sub[:views].to_i).to be > 0
+      expect(sub[:resolution]).to be_nil
+      expect(sub[:rating]).not_to be_blank
+      expect(sub[:keywords]).to be_instance_of Array
+      expect(sub[:keywords]).not_to be_empty
+      expect(sub[:keywords]).to include("squirrel")
+      expect(sub[:keywords]).to include("puma")
+    end
+
+    it 'displays music correctly' do
+      sub_id = "7009837"
+      sub = @fa.submission(sub_id)
+      expect(sub[:title]).not_to be_blank
+      expect(sub[:description]).not_to be_blank
+      expect(sub[:description_body]).to eql(sub[:description])
+      check_profile_link(sub)
+      check_avatar(sub[:avatar], sub[:profile_name])
+      check_submission_link(sub[:link], sub_id)
+      check_date(sub[:posted], sub[:posted_at])
+      expect(sub[:download]).to match(/https:\/\/d.facdn.net\/art\/[^\/]+\/music\/[0-9]+\/[0-9]+\..+\.(mp3|mid|wav|mpeg)/)
+      # For a music submission, full != download
+      expect(sub[:full]).not_to be_blank
+      expect(sub[:full]).not_to eql(sub[:download])
+      check_thumbnail_link(sub[:thumbnail], sub_id)
+      # Info box
+      expect(sub[:category]).not_to be_blank
+      expect(sub[:theme]).not_to be_blank
+      expect(sub[:favorites]).to match(/[0-9]+/)
+      expect(sub[:favorites].to_i).to be > 0
+      expect(sub[:comments]).to match(/[0-9]+/)
+      expect(sub[:comments].to_i).to be > 0
+      expect(sub[:views]).to match(/[0-9]+/)
+      expect(sub[:views].to_i).to be > 0
+      expect(sub[:resolution]).to be_nil
+      expect(sub[:rating]).not_to be_blank
+      expect(sub[:keywords]).to be_instance_of Array
+      expect(sub[:keywords]).not_to be_empty
+      expect(sub[:keywords]).to include("BLEEP")
+      expect(sub[:keywords]).to include("BLORP")
+    end
+
+    it 'handles flash files correctly' do
+      sub_id = "1586623"
+      sub = @fa.submission(sub_id)
+      expect(sub[:title]).not_to be_blank
+      expect(sub[:description]).not_to be_blank
+      expect(sub[:description_body]).to eql(sub[:description])
+      check_profile_link(sub)
+      check_avatar(sub[:avatar], sub[:profile_name])
+      check_submission_link(sub[:link], sub_id)
+      check_date(sub[:posted], sub[:posted_at])
+      expect(sub[:download]).to match(/https:\/\/d.facdn.net\/art\/[^\/]+\/[0-9]+\/[0-9]+\..+\.swf/)
+      # For a flash submission, full is nil
+      expect(sub[:full]).to be_nil
+      check_thumbnail_link(sub[:thumbnail], sub_id)
+      # Info box
+      expect(sub[:category]).not_to be_blank
+      expect(sub[:theme]).not_to be_blank
+      expect(sub[:favorites]).to match(/[0-9]+/)
+      expect(sub[:favorites].to_i).to be > 0
+      expect(sub[:comments]).to match(/[0-9]+/)
+      expect(sub[:comments].to_i).to be > 0
+      expect(sub[:views]).to match(/[0-9]+/)
+      expect(sub[:views].to_i).to be > 0
+      expect(sub[:resolution]).not_to be_blank
+      expect(sub[:rating]).not_to be_blank
+      expect(sub[:keywords]).to be_instance_of Array
+      expect(sub[:keywords]).not_to be_empty
+      expect(sub[:keywords]).to include("dog")
+      expect(sub[:keywords]).to include("DDR")
+    end
+
+    it 'handles poetry submissions correctly' do
+      sub_id = "5325854"
+      sub = @fa.submission(sub_id)
+      expect(sub[:title]).not_to be_blank
+      expect(sub[:description]).not_to be_blank
+      expect(sub[:description_body]).to eql(sub[:description])
+      check_profile_link(sub)
+      check_avatar(sub[:avatar], sub[:profile_name])
+      check_submission_link(sub[:link], sub_id)
+      check_date(sub[:posted], sub[:posted_at])
+      expect(sub[:download]).to match(/https:\/\/d.facdn.net\/art\/[^\/]+\/poetry\/[0-9]+\/[0-9]+\..+\.(rtf|doc|txt|docx|pdf)/)
+      # For a potery submission, full is nil
+      expect(sub[:full]).not_to be_nil
+      check_thumbnail_link(sub[:thumbnail], sub_id)
+      # Info box
+      expect(sub[:category]).not_to be_blank
+      expect(sub[:theme]).not_to be_blank
+      expect(sub[:favorites]).to match(/[0-9]+/)
+      expect(sub[:favorites].to_i).to be > 0
+      expect(sub[:comments]).to match(/[0-9]+/)
+      expect(sub[:comments].to_i).to be > 0
+      expect(sub[:views]).to match(/[0-9]+/)
+      expect(sub[:views].to_i).to be > 0
+      expect(sub[:resolution]).to be_blank
+      expect(sub[:rating]).not_to be_blank
+      expect(sub[:keywords]).to be_instance_of Array
+      expect(sub[:keywords]).not_to be_empty
+      expect(sub[:keywords]).to include("Love")
+      expect(sub[:keywords]).to include("mind")
+    end
+
+    it 'still displays correctly when logged in as submission owner' do
+      @fa.login_cookie = COOKIE_TEST_USER_2
+      expect(@fa.login_cookie).not_to be_nil
+      sub_id = "32006442"
+      sub = @fa.submission(sub_id)
+      expect(sub[:title]).not_to be_blank
+      expect(sub[:description]).not_to be_blank
+      expect(sub[:description_body]).to eql(sub[:description])
+      check_profile_link(sub)
+      check_avatar(sub[:avatar], sub[:profile_name])
+      check_submission_link(sub[:link], sub_id)
+      check_date(sub[:posted], sub[:posted_at])
+      expect(sub[:download]).to match(/https:\/\/d.facdn.net\/art\/[^\/]+\/[0-9]+\/[0-9]+\..+\.png/)
+      # For an image submission, full == download
+      expect(sub[:full]).to eql(sub[:download])
+      check_thumbnail_link(sub[:thumbnail], sub_id)
+      # Info box
+      expect(sub[:category]).not_to be_blank
+      expect(sub[:theme]).not_to be_blank
+      expect(sub[:species]).not_to be_blank
+      expect(sub[:gender]).not_to be_blank
+      expect(sub[:favorites]).to match(/[0-9]+/)
+      expect(sub[:favorites].to_i).to be >= 0
+      expect(sub[:comments]).to match(/[0-9]+/)
+      expect(sub[:comments].to_i).to be >= 0
+      expect(sub[:views]).to match(/[0-9]+/)
+      expect(sub[:views].to_i).to be >= 0
+      expect(sub[:resolution]).not_to be_blank
+      expect(sub[:rating]).not_to be_blank
+      expect(sub[:keywords]).to be_instance_of Array
+      expect(sub[:keywords]).to be_empty
+    end
+
+    it 'hides nsfw submission if sfw is set' do
+      @fa.safe_for_work = true
+      expect { @fa.submission("32011278") }.to raise_error(FASystemError)
+    end
+  end
+
+  context 'when viewing a journal post' do
+    it 'displays basic data correctly' do
+      journal_id = "6894930"
+      journal = @fa.journal(journal_id)
+      expect(journal[:title]).to eql("From Curl")
+      expect(journal[:description]).to start_with("<div class=\"journal-body\">")
+      expect(journal[:description]).to include("Curl Test")
+      expect(journal[:description]).to end_with("</div>")
+      expect(journal[:journal_header]).to be_nil
+      expect(journal[:journal_body]).to eql("Curl Test")
+      expect(journal[:journal_footer]).to be_nil
+      check_profile_link(journal)
+      check_avatar(journal[:avatar], journal[:profile_name])
+      expect(journal[:link]).to match(/https:\/\/www.furaffinity.net\/journal\/#{journal_id}\/?/)
+      check_date(journal[:posted], journal[:posted_at])
+    end
+
+    it 'fails when given non-existent journal' do
+      expect { @fa.journal("6894929") }.to raise_error(FASystemError)
+    end
+
+    it 'parses journal header, body and footer' do
+      journal_id = "9185920"
+      journal = @fa.journal(journal_id)
+      expect(journal[:title]).to eql("Test journal")
+      expect(journal[:description]).to start_with("<div class=\"journal-header\">")
+      expect(journal[:description]).to include("Example test header")
+      expect(journal[:description]).to include("<div class=\"journal-body\">")
+      expect(journal[:description]).to include("This is an example test journal, with header and footer")
+      expect(journal[:description]).to include("<div class=\"journal-footer\">")
+      expect(journal[:description]).to include("Example test footer")
+      expect(journal[:description]).to end_with("</div>")
+      expect(journal[:journal_header]).to eql("Example test header")
+      expect(journal[:journal_body]).to eql("This is an example test journal, with header and footer")
+      expect(journal[:journal_footer]).to eql("Example test footer")
+      check_profile_link(journal)
+      check_avatar(journal[:avatar], journal[:profile_name])
+      expect(journal[:link]).to match(/https:\/\/www.furaffinity.net\/journal\/#{journal_id}\/?/)
+      check_date(journal[:posted], journal[:posted_at])
+    end
+
+    it 'handles non existent journal header' do
+      journal_id = "9185944"
+      journal = @fa.journal(journal_id)
+      expect(journal[:title]).to eql("Testing journals")
+      expect(journal[:description]).to start_with("<div class=\"journal-body\">")
+      expect(journal[:description]).to include("Another test of journals, this one is for footer only")
+      expect(journal[:description]).to include("<div class=\"journal-footer\">")
+      expect(journal[:description]).to include("Footer, no header though")
+      expect(journal[:description]).to end_with("</div>")
+      expect(journal[:journal_header]).to be_nil
+      expect(journal[:journal_body]).to eql("Another test of journals, this one is for footer only")
+      expect(journal[:journal_footer]).to eql("Footer, no header though")
+      check_profile_link(journal)
+      check_avatar(journal[:avatar], journal[:profile_name])
+      expect(journal[:link]).to match(/https:\/\/www.furaffinity.net\/journal\/#{journal_id}\/?/)
+      check_date(journal[:posted], journal[:posted_at])
+    end
+  end
+
+  context 'when listing comments' do
+    context 'on a submission' do
+      it 'displays a valid list of top level comments' do
+        sub_id = "16437648"
+        comments = @fa.submission_comments(sub_id, false)
+        expect(comments).to be_instance_of Array
+        expect(comments).not_to be_empty
+        comments.each do |comment|
+          expect(comment[:id]).to match(/[0-9]+/)
+          check_profile_link(comment)
+          check_avatar(comment[:avatar], comment[:profile_name])
+          check_date(comment[:posted], comment[:posted_at])
+          expect(comment[:text]).not_to be_blank
+          expect(comment[:reply_to]).to be_blank
+          expect(comment[:reply_level]).to be 0
+        end
+      end
+
+      it 'handles empty comments section' do
+        sub_id = "16437675"
+        comments = @fa.submission_comments(sub_id, false)
+        expect(comments).to be_instance_of Array
+        expect(comments).to be_empty
+      end
+
+      it 'hides deleted comments by default' do
+        submission_id = "16437663"
+        comments = @fa.submission_comments(submission_id, false)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 1
+        expect(comments[0][:text]).to eql("Non-deleted comment")
+      end
+
+      it 'handles comments deleted by author when specified' do
+        submission_id = "16437663"
+        comments = @fa.submission_comments(submission_id, true)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 2
+        expect(comments[0]).to have_key(:id)
+        expect(comments[0][:text]).to eql("Non-deleted comment")
+        expect(comments[0][:is_deleted]).to be false
+        expect(comments[1]).to have_key(:id)
+        expect(comments[1][:text]).to eql("Comment hidden by its owner")
+        expect(comments[1][:is_deleted]).to be true
+      end
+
+      it 'handles comments deleted by submission owner when specified' do
+        submission_id = "32006442"
+        comments_not_deleted = @fa.submission_comments(submission_id, false)
+        expect(comments_not_deleted).to be_instance_of Array
+        expect(comments_not_deleted).to be_empty
+        # Ensure comments appear when viewing deleted
+        comments = @fa.submission_comments(submission_id, true)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 1
+        expect(comments[0]).to have_key(:id)
+        expect(comments[0][:text]).to eql("Comment hidden by  the page owner")
+        expect(comments[0][:is_deleted]).to be true
+      end
+
+      it 'fails when given non-existent submission' do
+        expect { @fa.submission_comments("16437650", false) }.to raise_error FASystemError
+      end
+      
+      it 'correctly parses replies and reply levels' do
+        comments = @fa.submission_comments("32006460", false)
+        # Check first comment
+        expect(comments[0][:id]).not_to be_blank
+        expect(comments[0][:profile_name]).to eql(TEST_USER_3)
+        check_profile_link(comments[0])
+        check_avatar(comments[0][:avatar], comments[0][:profile_name])
+        check_date(comments[0][:posted], comments[0][:posted_at])
+        expect(comments[0][:text]).to eql("Base comment")
+        expect(comments[0][:reply_to]).to be_blank
+        expect(comments[0][:reply_level]).to be 0
+        # Check second comment
+        expect(comments[1][:id]).not_to be_blank
+        expect(comments[1][:profile_name]).to eql(TEST_USER_3)
+        check_profile_link(comments[1])
+        check_avatar(comments[1][:avatar], comments[1][:profile_name])
+        check_date(comments[1][:posted], comments[1][:posted_at])
+        expect(comments[1][:text]).to eql("First reply")
+        expect(comments[1][:reply_to]).not_to be_blank
+        expect(comments[1][:reply_to]).to eql(comments[0][:id])
+        expect(comments[1][:reply_level]).to be 1
+        # Check third comment
+        expect(comments[2][:id]).not_to be_blank
+        expect(comments[2][:profile_name]).to eql("fafeed-no-watchers")
+        check_profile_link(comments[2])
+        check_avatar(comments[2][:avatar], comments[2][:profile_name])
+        check_date(comments[2][:posted], comments[2][:posted_at])
+        expect(comments[2][:text]).to eql("Another reply")
+        expect(comments[2][:reply_to]).not_to be_blank
+        expect(comments[2][:reply_to]).to eql(comments[1][:id])
+        expect(comments[2][:reply_level]).to be 2
+      end
+
+      it 'handles replies to deleted comments' do
+        comments = @fa.submission_comments("32052941", true)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 2
+        # Check hidden comment
+        expect(comments[1][:id]).not_to be_blank
+        expect(comments[0][:text]).to start_with("Comment hidden by")
+        expect(comments[0][:reply_to]).to eql("")
+        expect(comments[0][:reply_level]).to be 0
+        expect(comments[0][:is_deleted]).to be true
+        # Check reply comment
+        expect(comments[1][:id]).not_to be_blank
+        expect(comments[1][:text]).not_to start_with("Comment hidden by")
+        expect(comments[1]).to have_key(:profile_name)
+        expect(comments[1][:reply_level]).to be 1
+        expect(comments[1][:reply_to]).not_to be_blank
+        expect(comments[1][:is_deleted]).to be false
+      end
+
+      it 'handles replies to hidden deleted comments' do
+        comments = @fa.submission_comments("32052941", false)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 1
+        # Reply comment should be only comment
+        expect(comments[0][:id]).not_to be_blank
+        expect(comments[0][:text]).not_to start_with("Comment hidden by")
+        expect(comments[0]).to have_key(:profile_name)
+        expect(comments[0][:reply_level]).to be 1
+        expect(comments[0][:reply_to]).not_to be_blank
+      end
+
+      it 'handles 2 replies to the same comment' do
+        comments = @fa.submission_comments("32057670", false)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 3
+        # Base comment
+        expect(comments[0][:id]).not_to be_blank
+        expect(comments[0][:text]).to eql("Base level comment")
+        expect(comments[0][:reply_level]).to be 0
+        expect(comments[0][:reply_to]).to eql("")
+        # First reply
+        expect(comments[1][:id]).not_to be_blank
+        expect(comments[1][:text]).to eql("First reply comment")
+        expect(comments[1][:reply_level]).to be 1
+        expect(comments[1][:reply_to]).to eql(comments[0][:id])
+        # Second reply
+        expect(comments[2][:id]).not_to be_blank
+        expect(comments[2][:text]).to eql("Second reply comment")
+        expect(comments[2][:reply_level]).to be 1
+        expect(comments[2][:reply_to]).to eql(comments[0][:id])
+      end
+
+      it 'handles deleted replies to deleted comments' do
+        comments = @fa.submission_comments("32057697", true)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 2
+        # Check hidden comment
+        expect(comments[0][:id]).not_to be_blank
+        expect(comments[0][:text]).to start_with("Comment hidden by")
+        expect(comments[0][:reply_level]).to be 0
+        expect(comments[0][:reply_to]).to eql("")
+        expect(comments[0][:is_deleted]).to be true
+        # Check reply comment
+        expect(comments[0][:id]).not_to be_blank
+        expect(comments[1][:text]).to start_with("Comment hidden by")
+        expect(comments[1][:reply_level]).to be 1
+        expect(comments[1][:reply_to]).to eql(comments[0][:id])
+        expect(comments[0][:is_deleted]).to be true
+      end
+
+      it 'handles comments to max depth' do
+        comments = @fa.submission_comments("32057717", false)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 22
+        last_comment_id = ""
+        level = 0
+        comments.each do |comment|
+          expect(comment[:id]).to match(/[0-9]+/)
+          check_profile_link(comment)
+          check_avatar(comment[:avatar], comment[:profile_name])
+          check_date(comment[:posted], comment[:posted_at])
+          expect(comment[:text]).not_to be_blank
+          expect(comment[:reply_to]).to eql(last_comment_id)
+          expect(comment[:reply_level]).to be level
+
+          if level <= 19
+            last_comment_id = comment[:id]
+            level += 1
+          end
+        end
+      end
+
+      it 'handles edited comments' do
+        comments = @fa.submission_comments("32057705", false)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 2
+        # Check edited comment
+        expect(comments[0][:id]).to match(/[0-9]+/)
+        check_profile_link(comments[0])
+        check_avatar(comments[0][:avatar], comments[0][:profile_name])
+        check_date(comments[0][:posted], comments[0][:posted_at])
+        expect(comments[0][:text]).not_to be_blank
+        expect(comments[0][:reply_to]).to be_blank
+        expect(comments[0][:reply_level]).to be 0
+        # Check non-edited comment
+        expect(comments[1][:id]).to match(/[0-9]+/)
+        check_profile_link(comments[1])
+        check_avatar(comments[1][:avatar], comments[1][:profile_name])
+        check_date(comments[1][:posted], comments[1][:posted_at])
+        expect(comments[1][:text]).not_to be_blank
+        expect(comments[1][:reply_to]).to be_blank
+        expect(comments[1][:reply_level]).to be 0
+      end
+
+      it 'handles reply chain, followed by reply to base comment' do
+        comments = @fa.submission_comments("32058026", false)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 4
+        # Check base comment
+        expect(comments[0][:id]).to match(/[0-9]+/)
+        expect(comments[0][:text]).to eql("Base comment")
+        expect(comments[0][:reply_to]).to eql("")
+        expect(comments[0][:reply_level]).to be 0
+        # Check first reply
+        expect(comments[1][:id]).to match(/[0-9]+/)
+        expect(comments[1][:text]).to eql("First reply")
+        expect(comments[1][:reply_to]).to eql(comments[0][:id])
+        expect(comments[1][:reply_level]).to be 1
+        # Check deep reply
+        expect(comments[2][:id]).to match(/[0-9]+/)
+        expect(comments[2][:text]).to eql("Deep reply")
+        expect(comments[2][:reply_to]).to eql(comments[1][:id])
+        expect(comments[2][:reply_level]).to be 2
+        # Check second reply
+        expect(comments[3][:id]).to match(/[0-9]+/)
+        expect(comments[3][:text]).to eql("Second base reply")
+        expect(comments[3][:reply_to]).to eql(comments[0][:id])
+        expect(comments[3][:reply_level]).to be 1
+      end
+    end
+
+    context 'on a journal' do
+      it 'displays a valid list of top level comments' do
+        journal_id = "6704315"
+        comments = @fa.journal_comments(journal_id, false)
+        expect(comments).to be_instance_of Array
+        expect(comments).not_to be_empty
+        comments.each do |comment|
+          expect(comment[:id]).to match(/[0-9]+/)
+          check_profile_link(comment)
+          check_avatar(comment[:avatar], comment[:profile_name])
+          check_date(comment[:posted], comment[:posted_at])
+          expect(comment[:text]).not_to be_blank
+          expect(comment[:reply_to]).to be_blank
+          expect(comment[:reply_level]).to be 0
+        end
+      end
+
+      it 'handles empty comments section' do
+        journal_id = "6704317"
+        comments = @fa.journal_comments(journal_id, false)
+        expect(comments).to be_instance_of Array
+        expect(comments).to be_empty
+      end
+
+      it 'hides deleted comments by default' do
+        journal_id = "6704520"
+        comments = @fa.journal_comments(journal_id, false)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 1
+        expect(comments[0][:text]).to eql("Non-deleted comment")
+      end
+
+      it 'handles comments deleted by author when specified' do
+        journal_id = "6704520"
+        comments = @fa.journal_comments(journal_id, true)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 2
+        expect(comments[0]).to have_key(:id)
+        expect(comments[0][:text]).to eql("Non-deleted comment")
+        expect(comments[0][:is_deleted]).to be false
+        expect(comments[1]).to have_key(:id)
+        expect(comments[1][:text]).to eql("Comment hidden by its owner")
+        expect(comments[1][:is_deleted]).to be true
+      end
+
+      it 'handles comments deleted by journal owner when specified' do
+        journal_id = "9185920"
+        comments_not_deleted = @fa.journal_comments(journal_id, false)
+        expect(comments_not_deleted).to be_instance_of Array
+        expect(comments_not_deleted).to be_empty
+        # Ensure comments appear when viewing deleted
+        comments = @fa.journal_comments(journal_id, true)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 1
+        expect(comments[0]).to have_key(:id)
+        expect(comments[0][:text]).to eql("Comment hidden by  the page owner")
+        expect(comments[0][:is_deleted]).to be true
+      end
+
+      it 'fails when given non-existent journal' do
+        expect { @fa.journal_comments("6894929", false) }.to raise_error(FASystemError)
+      end
+
+      it 'correctly parses replies and reply levels' do
+        comments = @fa.journal_comments("6894788", false)
+        # Check first comment
+        expect(comments[0][:id]).not_to be_blank
+        expect(comments[0][:profile_name]).to eql(TEST_USER_3)
+        check_profile_link(comments[0])
+        check_avatar(comments[0][:avatar], comments[0][:profile_name])
+        check_date(comments[0][:posted], comments[0][:posted_at])
+        expect(comments[0][:text]).to eql("Base journal comment")
+        expect(comments[0][:reply_to]).to be_blank
+        expect(comments[0][:reply_level]).to be 0
+        # Check second comments
+        expect(comments[1][:id]).not_to be_blank
+        expect(comments[1][:profile_name]).to eql(TEST_USER_3)
+        check_profile_link(comments[1])
+        check_avatar(comments[1][:avatar], comments[1][:profile_name])
+        check_date(comments[1][:posted], comments[1][:posted_at])
+        expect(comments[1][:text]).to eql("Reply to journal comment")
+        expect(comments[1][:reply_to]).not_to be_blank
+        expect(comments[1][:reply_to]).to eql(comments[0][:id])
+        expect(comments[1][:reply_level]).to be 1
+        # Check third comments
+        expect(comments[2][:id]).not_to be_blank
+        expect(comments[2][:profile_name]).to eql("fafeed-no-watchers")
+        check_profile_link(comments[2])
+        check_avatar(comments[2][:avatar], comments[2][:profile_name])
+        check_date(comments[2][:posted], comments[2][:posted_at])
+        expect(comments[2][:text]).to eql("Another reply on this journal")
+        expect(comments[2][:reply_to]).not_to be_blank
+        expect(comments[2][:reply_to]).to eql(comments[1][:id])
+        expect(comments[2][:reply_level]).to be 2
+      end
+
+      it 'handles replies to deleted comments' do
+        comments = @fa.journal_comments("9187935", true)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 2
+        # Check hidden comment
+        expect(comments[0][:id]).not_to be_blank
+        expect(comments[0][:text]).to start_with("Comment hidden by")
+        expect(comments[0][:reply_to]).to eql("")
+        expect(comments[0][:reply_level]).to be 0
+        expect(comments[0][:is_deleted]).to be true
+        # Check reply comment
+        expect(comments[1][:id]).not_to be_blank
+        expect(comments[1][:text]).not_to start_with("Comment hidden by")
+        expect(comments[1]).to have_key(:profile_name)
+        expect(comments[1][:reply_level]).to be 1
+        expect(comments[1][:reply_to]).to eql(comments[0][:id])
+        expect(comments[1][:is_deleted]).to be false
+      end
+
+      it 'handles replies to hidden deleted comments' do
+        comments = @fa.journal_comments("9187935", false)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 1
+        # Reply comment should be only comment
+        expect(comments[0][:id]).not_to be_blank
+        expect(comments[0][:text]).not_to start_with("Comment hidden by")
+        expect(comments[0]).to have_key(:profile_name)
+        expect(comments[0][:reply_level]).to be 1
+        expect(comments[0][:reply_to]).not_to be_blank
+      end
+
+      it 'handles 2 replies to the same comment' do
+        comments = @fa.journal_comments("9187933", false)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 3
+        # Base comment
+        expect(comments[0][:id]).not_to be_blank
+        expect(comments[0][:text]).to eql("Base comment")
+        expect(comments[0][:reply_level]).to be 0
+        expect(comments[0][:reply_to]).to eql("")
+        # First reply
+        expect(comments[1][:id]).not_to be_blank
+        expect(comments[1][:text]).to eql("First reply")
+        expect(comments[1][:reply_level]).to be 1
+        expect(comments[1][:reply_to]).to eql(comments[0][:id])
+        # Second reply
+        expect(comments[2][:id]).not_to be_blank
+        expect(comments[2][:text]).to eql("Second reply")
+        expect(comments[2][:reply_level]).to be 1
+        expect(comments[2][:reply_to]).to eql(comments[0][:id])
+      end
+
+      it 'handles deleted replies to deleted comments' do
+        comments = @fa.journal_comments("9187934", true)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 2
+        # Check hidden comment
+        expect(comments[0]).to have_key(:id)
+        expect(comments[0][:text]).to start_with("Comment hidden by")
+        expect(comments[0][:reply_level]).to be 0
+        expect(comments[0][:reply_to]).to eql("")
+        expect(comments[0][:is_deleted]).to be true
+        # Check reply comment
+        expect(comments[1]).to have_key(:id)
+        expect(comments[1][:text]).to start_with("Comment hidden by")
+        expect(comments[1][:reply_level]).to be 1
+        expect(comments[1][:reply_to]).to eql(comments[0][:id])
+        expect(comments[1][:is_deleted]).to be true
+      end
+
+      it 'handles comments to max depth' do
+        comments = @fa.submission_comments("32057717", false)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 22
+        last_comment_id = ""
+        level = 0
+        comments.each do |comment|
+          expect(comment[:id]).to match(/[0-9]+/)
+          check_profile_link(comment)
+          check_avatar(comment[:avatar], comment[:profile_name])
+          check_date(comment[:posted], comment[:posted_at])
+          expect(comment[:text]).not_to be_blank
+          expect(comment[:reply_to]).to eql(last_comment_id)
+          expect(comment[:reply_level]).to be level
+
+          if level <= 19
+            last_comment_id = comment[:id]
+            level += 1
+          end
+        end
+      end
+
+      it 'handles edited comments' do
+        comments = @fa.journal_comments("9187948", false)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 2
+        # Check edited comment
+        expect(comments[0][:id]).to match(/[0-9]+/)
+        check_profile_link(comments[0])
+        check_avatar(comments[0][:avatar], comments[0][:profile_name])
+        check_date(comments[0][:posted], comments[0][:posted_at])
+        expect(comments[0][:text]).not_to be_blank
+        expect(comments[0][:reply_to]).to be_blank
+        expect(comments[0][:reply_level]).to be 0
+        # Check non-edited comment
+        expect(comments[1][:id]).to match(/[0-9]+/)
+        check_profile_link(comments[1])
+        check_avatar(comments[1][:avatar], comments[1][:profile_name])
+        check_date(comments[1][:posted], comments[1][:posted_at])
+        expect(comments[1][:text]).not_to be_blank
+        expect(comments[1][:reply_to]).to be_blank
+        expect(comments[1][:reply_level]).to be 0
+      end
+
+      it 'handles reply chain, followed by reply to base comment' do
+        comments = @fa.journal_comments("9187949", false)
+        expect(comments).to be_instance_of Array
+        expect(comments.length).to be 4
+        # Check base comment
+        expect(comments[0][:id]).to match(/[0-9]+/)
+        expect(comments[0][:text]).to eql("Base comment")
+        expect(comments[0][:reply_to]).to eql("")
+        expect(comments[0][:reply_level]).to be 0
+        # Check first reply
+        expect(comments[1][:id]).to match(/[0-9]+/)
+        expect(comments[1][:text]).to eql("First reply")
+        expect(comments[1][:reply_to]).to eql(comments[0][:id])
+        expect(comments[1][:reply_level]).to be 1
+        # Check deep reply
+        expect(comments[2][:id]).to match(/[0-9]+/)
+        expect(comments[2][:text]).to eql("Deep reply")
+        expect(comments[2][:reply_to]).to eql(comments[1][:id])
+        expect(comments[2][:reply_level]).to be 2
+        # Check second reply
+        expect(comments[3][:id]).to match(/[0-9]+/)
+        expect(comments[3][:text]).to eql("Second base reply")
+        expect(comments[3][:reply_to]).to eql(comments[0][:id])
+        expect(comments[3][:reply_level]).to be 1
+      end
+    end
+  end
+
+  context 'when searching submissions' do
+    it 'returns a list of submission data' do
+      results = @fa.search({"q" => "YCH"})
+      expect(results).to be_instance_of Array
+      expect(results).not_to be_empty
+      results.each(&method(:check_submission))
+    end
+
+    it 'handles blank search cleanly' do
+      results = @fa.search({q: ""})
+      expect(results).to be_instance_of Array
+      expect(results).to be_empty
+    end
+
+    it 'handles search queries with a space in them' do
+      results = @fa.search({"q" => "YCH deer"})
+      expect(results).to be_instance_of Array
+      expect(results).not_to be_empty
+      results.each(&method(:check_submission))
+    end
+
+    it 'displays a different page 1 to page 2' do
+      # Get page 1
+      results1 = @fa.search({"q" => "YCH"})
+      expect(results1).to be_instance_of Array
+      expect(results1).not_to be_empty
+      # Get page 2
+      results2 = @fa.search({"q" => "YCH", "page" => "2"})
+      expect(results2).to be_instance_of Array
+      expect(results2).not_to be_empty
+      # Check they're different enough
+      check_results_lists_are_different(results1, results2)
+    end
+
+    it 'works when making the same search twice' do
+      # There was an awkward caching issue breaking this, hence this test.
+      results1 = @fa.search({"q" => "YCH"})
+      expect(results1).to be_instance_of Array
+      expect(results1).not_to be_empty
+      expect(results1.length).to be > 20
+      # Get page 2
+      results2 = @fa.search({"q" => "YCH"})
+      expect(results2).to be_instance_of Array
+      expect(results2).not_to be_empty
+      expect(results2.length).to be > 20
+    end
+
+    it 'returns a specific set of test submissions when using a rare test keyword' do
+      results = @fa.search({"q" => "rare_test_keyword"})
+      expect(results).to be_instance_of Array
+      expect(results).not_to be_empty
+      expect(results.length).to be 3
+      result_id_list = results.map{|result| result[:id]}
+      expect(result_id_list).to include("32052941")
+      expect(result_id_list).to include("32057670")
+      expect(result_id_list).to include("32057697")
+    end
+
+    it 'displays a number of results equal to the perpage setting' do
+      results_long = @fa.search({"q" => "YCH", "perpage" => "72"})
+      expect(results_long).to be_instance_of Array
+      expect(results_long).not_to be_empty
+      expect(results_long.length).to be >= 70
+
+      results_med = @fa.search({"q" => "YCH", "perpage" => "48"})
+      expect(results_med).to be_instance_of Array
+      expect(results_med).not_to be_empty
+      expect(results_med.length).to be >= 46
+      expect(results_med.length).to be < 49
+
+      results_short = @fa.search({"q" => "YCH", "perpage" => "24"})
+      expect(results_short).to be_instance_of Array
+      expect(results_short).not_to be_empty
+      expect(results_short.length).to be >= 22
+      expect(results_short.length).to be < 25
+    end
+
+    it 'defaults to ordering by date desc' do
+      results = @fa.search({"q" => "YCH", "perpage" => "72"})
+      expect(results).to be_instance_of Array
+      expect(results).not_to be_empty
+      results_date = @fa.search({"q" => "YCH", "perpage" => "72", "order_by" => "date"})
+      expect(results).to be_instance_of Array
+      expect(results).not_to be_empty
+
+      # Check they're similar enough
+      check_results_lists_are_similar(results, results_date)
+
+      # Check it's roughly date ordered. FA results are not exactly date ordered.
+      first_submission = @fa.submission(results[0][:id])
+      first_datetime = Time.parse(first_submission[:posted] + ' UTC')
+      last_submission = @fa.submission(results[-1][:id])
+      last_datetime = Time.parse(last_submission[:posted] + ' UTC')
+      expect(last_datetime).to be < first_datetime
+    end
+
+    it 'can search by relevancy and popularity, which give a different order to date' do
+      results_date = @fa.search({"q" => "YCH", "perpage" => "24", "order_by" => "date"})
+      results_rele = @fa.search({"q" => "YCH", "perpage" => "24", "order_by" => "relevancy"})
+      results_popu = @fa.search({"q" => "YCH", "perpage" => "24", "order_by" => "popularity"})
+      check_results_lists_are_different(results_date, results_rele)
+      check_results_lists_are_different(results_rele, results_popu)
+      check_results_lists_are_different(results_popu, results_date)
+    end
+
+    it 'can specify order direction as ascending' do
+      results_asc = @fa.search({"q" => "YCH", "perpage" => "24", "order_direction" => "asc"})
+      results_desc = @fa.search({"q" => "YCH", "perpage" => "24", "order_direction" => "desc"})
+      check_results_lists_are_different(results_asc, results_desc)
+    end
+
+    it 'can specify shorter range, which delivers fewer results' do
+      big_results = @fa.search({"q" => "garden", "perpage" => 72})
+      expect(big_results).to be_instance_of Array
+      expect(big_results).not_to be_empty
+      small_results = @fa.search({"q" => "garden", "perpage" => 72, "range" => "day"})
+      expect(small_results).to be_instance_of Array
+      expect(small_results).not_to be_empty
+
+      expect(big_results.length).to be > small_results.length
+    end
+
+    it 'can specify search mode for the terms in the query' do
+      extended_or_results = @fa.search({"q" => "deer | lion", "perpage" => 72})
+      extended_and_results = @fa.search({"q" => "deer & lion", "perpage" => 72})
+      or_results = @fa.search({"q" => "deer lion", "perpage" => 72, "mode" => "any"})
+      and_results = @fa.search({"q" => "deer lion", "perpage" => 72, "mode" => "all"})
+
+      check_results_lists_are_different(extended_and_results, extended_or_results)
+      check_results_lists_are_different(and_results, or_results)
+
+      check_results_lists_are_similar(extended_or_results, or_results)
+      check_results_lists_are_similar(extended_and_results, and_results)
+    end
+
+    it 'can specify ratings to display, and honours that selection' do
+      only_adult = @fa.search({"q" => "ych", "perpage" => 24, "rating" => "adult"})
+      only_sfw_or_mature = @fa.search({"q" => "ych", "perpage" => 24, "rating" => "mature,general"})
+
+      check_results_lists_are_different(only_adult, only_sfw_or_mature)
+
+      only_adult.each do |submission|
+        full_submission = @fa.submission(submission[:id])
+        expect(full_submission[:rating]).to eql("Adult")
+      end
+
+      general_count = 0
+      mature_count = 0
+      only_sfw_or_mature.each do |submission|
+        full_submission = @fa.submission(submission[:id])
+        expect(full_submission[:rating]).not_to eql("Adult")
+        if full_submission[:rating] == "General"
+          general_count += 1
+        else
+          mature_count += 1
+        end
+      end
+      expect(general_count).to be > 0
+      expect(mature_count).to be > 0
+    end
+
+    it 'displays only sfw results when only adult is selected, and sfw mode is on' do
+      @fa.safe_for_work = true
+      results = @fa.search({"q" => "ych", "perpage" => 24, "rating" => "adult"})
+      results.each do |submission|
+        begin
+          full_submission = @fa.submission(submission[:id])
+          expect(full_submission[:rating]).to eql("General")
+        rescue FASystemError
+        end
+      end
+    end
+
+    it 'can specify a content type for results, only returns that content type' do
+      results_poem = @fa.search({"q" => "deer", "perpage" => 72, "type" => "poetry"})
+      results_photo = @fa.search({"q" => "deer", "perpage" => 72, "type" => "photo"})
+      check_results_lists_are_different(results_photo, results_poem)
+    end
+
+    it 'can specify multiple content types for results, and only displays those types' do
+      results_image = @fa.search({"q" => "deer", "perpage" => 72, "type" => "photo,art"})
+      results_swf_music = @fa.search({"q" => "deer", "perpage" => 72, "type" => "flash,music"})
+      check_results_lists_are_different(results_image, results_swf_music)
+    end
+
+    it 'ignores other unused parameters' do
+      results = @fa.search({"q" => "ych", "foo" => "bar"})
+      expect(results).to be_instance_of Array
+      expect(results).not_to be_empty
+    end
+
+    it 'raises an error if given invalid option for a parameter' do
+      expect { @fa.search({"q" => "ych", "perpage" => 100}) }.to raise_error(FASearchError)
+    end
+
+    it 'raises an error if given an invalid option for a multi-value parameter' do
+      expect { @fa.search({"q" => "ych", "rating" => "adult,lewd"}) }.to raise_error(FASearchError)
+    end
+  end
+
+  context 'when reading new submission notifications' do
+    it 'will correctly parse current user' do
+      @fa.login_cookie = COOKIE_TEST_USER_2
+      new_subs = @fa.new_submissions(nil)
+      expect(new_subs[:current_user][:name]).to eql(TEST_USER_2)
+      check_profile_link(new_subs[:current_user])
+    end
+
+    it 'should handle zero notifications' do
+      @fa.login_cookie = COOKIE_TEST_USER_2
+      new_subs = @fa.new_submissions(nil)
+      expect(new_subs[:new_submissions]).to be_instance_of Array
+      expect(new_subs[:new_submissions]).to be_empty
+    end
+
+    it 'should hide nsfw submissions if sfw=1 is specified' do
+      @fa.login_cookie = COOKIE_TEST_USER_3
+      new_subs = @fa.new_submissions(nil)
+
+      @fa.safe_for_work = true
+      new_safe_subs = @fa.new_submissions(nil)
+
+      expect(new_safe_subs[:new_submissions].length).to be < new_subs[:new_submissions].length
+    end
+
+    it 'returns a valid list of new submission notifications' do
+      @fa.login_cookie = COOKIE_TEST_USER_3
+      new_subs = @fa.new_submissions(nil)
+      expect(new_subs[:new_submissions]).to be_instance_of Array
+      expect(new_subs[:new_submissions]).not_to be_empty
+      new_subs[:new_submissions].each(&method(:check_submission))
+    end
+
+    it 'handles paging correctly' do
+      @fa.login_cookie = COOKIE_TEST_USER_3
+      all_subs = @fa.new_submissions(nil)[:new_submissions]
+      expect(all_subs).to be_instance_of Array
+      expect(all_subs).not_to be_empty
+
+      second_sub_id = all_subs[1][:id]
+      all_from_second = @fa.new_submissions(second_sub_id)[:new_submissions]
+      expect(all_from_second).to be_instance_of Array
+      expect(all_from_second).not_to be_empty
+
+      all_after_second = @fa.new_submissions(second_sub_id.to_i-1)[:new_submissions]
+      expect(all_after_second).to be_instance_of Array
+      expect(all_after_second).not_to be_empty
+
+      expect(all_from_second.length).to be(all_subs.length - 1)
+      expect(all_from_second[0][:id]).to eql(all_subs[1][:id])
+      expect(all_after_second.length).to be(all_subs.length - 2)
+      expect(all_after_second[0][:id]).to eql(all_subs[2][:id])
+    end
+  end
+
+  context 'when reading notifications' do
+    it 'will correctly parse current user' do
+      @fa.login_cookie = COOKIE_TEST_USER_2
+      notifications = @fa.notifications(false)
+      expect(notifications[:current_user][:name]).to eql(TEST_USER_2)
+      check_profile_link(notifications[:current_user])
+    end
+
+    it 'should not return anything unless login cookie is given' do
+      @fa.login_cookie = nil
+      expect { @fa.notifications(false) }.to raise_error(FALoginError)
+    end
+
+    it 'should contain all 6 types of notifications' do
+      @fa.login_cookie = COOKIE_TEST_USER_2
+      notifications = @fa.notifications(false)
+      expect(notifications).to have_key(:new_watches)
+      expect(notifications).to have_key(:new_submission_comments)
+      expect(notifications).to have_key(:new_journal_comments)
+      expect(notifications).to have_key(:new_shouts)
+      expect(notifications).to have_key(:new_favorites)
+      expect(notifications).to have_key(:new_journals)
+    end
+
+    context 'watcher notifications' do
+      it 'should handle zero new watchers' do
+        @fa.login_cookie = COOKIE_TEST_USER_3
+        watchers = @fa.notifications(false)[:new_watches]
+        expect(watchers).to be_instance_of Array
+        expect(watchers).to be_empty
+      end
+
+      it 'returns a list of new watcher notifications' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        watchers = @fa.notifications(false)[:new_watches]
+        expect(watchers).to be_instance_of Array
+        expect(watchers).not_to be_empty
+        watchers.each do |watcher|
+          expect(watcher[:watch_id]).to match(/[0-9]+/)
+          check_profile_link(watcher)
+          check_avatar(watcher[:avatar], watcher[:profile_name])
+          check_date(watcher[:posted], watcher[:posted_at])
+        end
+      end
+
+      it 'should hide deleted watcher notifications by default' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        watchers = @fa.notifications(false)[:new_watches]
+        expect(watchers).to be_instance_of Array
+        expect(watchers).not_to be_empty
+        expect(watchers.length).to be 1
+      end
+
+      it 'should display deleted watcher notifications when specified and hide otherwise' do
+        skip "Skipped: Looks like deleted watcher notifications don't display anymore"
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        watchers = @fa.notifications(false)[:new_watches]
+        expect(watchers).to be_instance_of Array
+        expect(watchers).not_to be_empty
+
+        watchers_deleted = @fa.notifications(true)[:new_watches]
+        expect(watchers_deleted).to be_instance_of Array
+        expect(watchers_deleted).not_to be_empty
+
+        expect(watchers_deleted.length).to be > watchers.length
+
+        deleted_watch = watchers_deleted[-1]
+        expect(deleted_watch[:watch_id]).to eql("")
+        expect(deleted_watch[:name]).to eql("Removed by the user")
+        expect(deleted_watch[:profile]).to eql("")
+        expect(deleted_watch[:profile_name]).to eql("")
+        expect(deleted_watch[:avatar]).to eql("I forgot the link.")
+        expect(deleted_watch[:posted]).to eql("")
+        expect(deleted_watch[:posted_at]).to eql("")
+      end
+    end
+
+    context 'submission comment notifications' do
+      it 'should handle zero submission comment notifications' do
+        @fa.login_cookie = COOKIE_TEST_USER_NO_NOTIFICATIONS
+        notifications = @fa.notifications(false)[:new_submission_comments]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).to be_empty
+      end
+
+      it 'returns a list of new submission comment notifications' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        notifications = @fa.notifications(false)[:new_submission_comments]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).not_to be_empty
+        notifications.each do |comment_notification|
+          expect(comment_notification[:comment_id]).to match(/[0-9]+/)
+          check_profile_link(comment_notification)
+          expect(comment_notification[:is_reply]).to be_in([true, false])
+          expect(comment_notification[:your_submission]).to be_in([true, false])
+          expect(comment_notification[:their_submission]).to be_in([true, false])
+          # Can't be both yours and theirs
+          expect(comment_notification[:your_submission] && comment_notification[:their_submission]).to be false
+          expect(comment_notification[:submission_id]).to match(/[0-9]+/)
+          expect(comment_notification[:title]).not_to be_blank
+          check_date(comment_notification[:posted], comment_notification[:posted_at])
+        end
+      end
+
+      it 'correctly parses base level comments to your submissions' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        notifications = @fa.notifications(false)[:new_submission_comments]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).not_to be_empty
+
+        found_comment = false
+
+        notifications.each do |comment_notification|
+          if !comment_notification[:is_reply] &&
+              comment_notification[:your_submission] &&
+              !comment_notification[:their_submission]
+            found_comment = true
+          end
+        end
+
+        expect(found_comment).to be true
+      end
+
+      it 'correctly parses replies to your comments on your submissions' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        notifications = @fa.notifications(false)[:new_submission_comments]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).not_to be_empty
+
+        found_comment = false
+
+        notifications.each do |comment_notification|
+          if comment_notification[:is_reply] &&
+              comment_notification[:your_submission] &&
+              !comment_notification[:their_submission]
+            found_comment = true
+          end
+        end
+
+        expect(found_comment).to be true
+      end
+
+      it 'correctly parses replies to your comments on their submissions' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        notifications = @fa.notifications(false)[:new_submission_comments]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).not_to be_empty
+
+        found_comment = false
+
+        notifications.each do |comment_notification|
+          if comment_notification[:is_reply] &&
+              !comment_notification[:your_submission] &&
+              comment_notification[:their_submission]
+            found_comment = true
+          end
+        end
+
+        expect(found_comment).to be true
+      end
+
+      it 'correctly parses replies to your comments on someone else\'s submissions' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        notifications = @fa.notifications(false)[:new_submission_comments]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).not_to be_empty
+
+        found_comment = false
+
+        notifications.each do |comment_notification|
+          if comment_notification[:is_reply] &&
+              !comment_notification[:your_submission] &&
+              !comment_notification[:their_submission]
+            found_comment = true
+          end
+        end
+
+        expect(found_comment).to be true
+      end
+
+      it 'displays deleted submission comment notifications when specified and hide otherwise' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        notifications = @fa.notifications(false)[:new_submission_comments]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).not_to be_empty
+
+        notifications_include = @fa.notifications(true)[:new_submission_comments]
+        expect(notifications_include).to be_instance_of Array
+        expect(notifications_include).not_to be_empty
+
+        expect(notifications_include.length).to be > notifications.length
+
+        deleted = notifications_include - notifications
+
+        deleted.each do |deleted_comment|
+          expect(deleted_comment[:comment_id]).to eql("")
+          expect(deleted_comment[:name]).to eql("Comment or the submission it was left on has been deleted")
+          expect(deleted_comment[:profile]).to eql("")
+          expect(deleted_comment[:profile_name]).to eql("")
+          expect(deleted_comment[:is_reply]).to be false
+          expect(deleted_comment[:your_submission]).to be false
+          expect(deleted_comment[:their_submission]).to be false
+          expect(deleted_comment[:submission_id]).to eql("")
+          expect(deleted_comment[:title]).to eql("Comment or the submission it was left on has been deleted")
+          expect(deleted_comment[:posted]).to eql("")
+          expect(deleted_comment[:posted_at]).to eql("")
+        end
+      end
+    end
+
+    context 'journal comment notifications' do
+      it 'should handle zero journal comment notifications' do
+        @fa.login_cookie = COOKIE_TEST_USER_NO_NOTIFICATIONS
+        notifications = @fa.notifications(false)[:new_journal_comments]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).to be_empty
+      end
+
+      it 'returns a list of new journal comment notifications' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        notifications = @fa.notifications(false)[:new_journal_comments]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).not_to be_empty
+        notifications.each do |comment_notification|
+          expect(comment_notification[:comment_id]).to match(/[0-9]+/)
+          check_profile_link(comment_notification)
+          expect(comment_notification[:is_reply]).to be_in([true, false])
+          expect(comment_notification[:your_journal]).to be_in([true, false])
+          expect(comment_notification[:their_journal]).to be_in([true, false])
+          expect(comment_notification[:your_journal] && comment_notification[:their_journal]).to be false
+          expect(comment_notification[:journal_id]).to match(/[0-9]+/)
+          expect(comment_notification[:title]).not_to be_blank
+          check_date(comment_notification[:posted], comment_notification[:posted_at])
+        end
+      end
+
+      it 'correctly parses base level comments to your journals' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        notifications = @fa.notifications(false)[:new_journal_comments]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).not_to be_empty
+
+        found_comment = false
+
+        notifications.each do |comment_notification|
+          if !comment_notification[:is_reply] &&
+              comment_notification[:your_journal] &&
+              !comment_notification[:their_journal]
+            found_comment = true
+          end
+        end
+
+        expect(found_comment).to be true
+      end
+
+      it 'correctly parses replies to your comments on your journals' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        notifications = @fa.notifications(false)[:new_journal_comments]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).not_to be_empty
+
+        found_comment = false
+
+        notifications.each do |comment_notification|
+          if comment_notification[:is_reply] &&
+              comment_notification[:your_journal] &&
+              !comment_notification[:their_journal]
+            found_comment = true
+          end
+        end
+
+        expect(found_comment).to be true
+      end
+
+      it 'correctly parses replies to your comments on their journals' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        notifications = @fa.notifications(false)[:new_journal_comments]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).not_to be_empty
+
+        found_comment = false
+
+        notifications.each do |comment_notification|
+          if comment_notification[:is_reply] &&
+              !comment_notification[:your_journal] &&
+              comment_notification[:their_journal]
+            found_comment = true
+          end
+        end
+
+        expect(found_comment).to be true
+      end
+
+      it 'correctly parses replies to your comments on someone else\'s journals' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        notifications = @fa.notifications(false)[:new_journal_comments]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).not_to be_empty
+
+        found_comment = false
+
+        notifications.each do |comment_notification|
+          if comment_notification[:is_reply] &&
+              !comment_notification[:your_journal] &&
+              !comment_notification[:their_journal]
+            found_comment = true
+          end
+        end
+
+        expect(found_comment).to be true
+      end
+
+      it 'displays deleted journal comment notifications when specified and hide otherwise' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        notifications = @fa.notifications(false)[:new_journal_comments]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).not_to be_empty
+
+        notifications_include = @fa.notifications(true)[:new_journal_comments]
+        expect(notifications_include).to be_instance_of Array
+        expect(notifications_include).not_to be_empty
+
+        expect(notifications_include.length).to be > notifications.length
+
+        deleted = notifications_include - notifications
+
+        deleted.each do |deleted_comment|
+          expect(deleted_comment[:comment_id]).to eql("")
+          expect(deleted_comment[:name]).to eql("Comment or the journal it was left on has been deleted")
+          expect(deleted_comment[:profile]).to eql("")
+          expect(deleted_comment[:profile_name]).to eql("")
+          expect(deleted_comment[:is_reply]).to be false
+          expect(deleted_comment[:your_journal]).to be false
+          expect(deleted_comment[:their_journal]).to be false
+          expect(deleted_comment[:journal_id]).to eql("")
+          expect(deleted_comment[:title]).to eql("Comment or the journal it was left on has been deleted")
+          expect(deleted_comment[:posted]).to eql("")
+          expect(deleted_comment[:posted_at]).to eql("")
+        end
+      end
+    end
+
+    context 'shout notifications' do
+      it 'should handle zero shout notifications' do
+        @fa.login_cookie = COOKIE_TEST_USER_NO_NOTIFICATIONS
+        notifications = @fa.notifications(false)[:new_shouts]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).to be_empty
+      end
+
+      it 'returns a list of new shout notifications' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        notifications = @fa.notifications(false)[:new_shouts]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).not_to be_empty
+
+        notifications.each do |new_shout|
+          expect(new_shout[:shout_id]).to match(/[0-9]+/)
+          check_profile_link(new_shout)
+          check_date(new_shout[:posted], new_shout[:posted_at])
+        end
+      end
+
+      it 'displays deleted shout notifications when specified and hides otherwise' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        notifications = @fa.notifications(false)[:new_shouts]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).not_to be_empty
+
+        notifications_include = @fa.notifications(true)[:new_shouts]
+        expect(notifications_include).to be_instance_of Array
+        expect(notifications_include).not_to be_empty
+
+        expect(notifications_include.length).to be > notifications.length
+
+        deleted = notifications_include - notifications
+
+        deleted.each do |deleted_shout|
+          expect(deleted_shout[:shout_id]).to eql("")
+          expect(deleted_shout[:name]).to eql("Shout has been removed from your page")
+          expect(deleted_shout[:profile]).to eql("")
+          expect(deleted_shout[:profile_name]).to eql("")
+          expect(deleted_shout[:posted]).to eql("")
+          expect(deleted_shout[:posted_at]).to eql("")
+        end
+      end
+    end
+
+    context 'favourite notifications' do
+      it 'should handle zero favourite notifications' do
+        @fa.login_cookie = COOKIE_TEST_USER_NO_NOTIFICATIONS
+        notifications = @fa.notifications(false)[:new_favorites]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).to be_empty
+      end
+
+      it 'returns a list of new favourite notifications' do
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        notifications = @fa.notifications(false)[:new_favorites]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).not_to be_empty
+
+        notifications.each do |new_fav|
+          expect(new_fav[:favorite_notification_id]).to match(/[0-9]+/)
+          check_profile_link(new_fav)
+          expect(new_fav[:submission_id]).to match(/[0-9]+/)
+          expect(new_fav[:submission_name]).not_to be_blank
+          check_date(new_fav[:posted], new_fav[:posted_at])
+        end
+      end
+
+      it 'displays deleted favourite notifications when specified and hides otherwise' do
+        skip "Skipped: Looks like deleted favourite notifications don't display anymore"
+        @fa.login_cookie = COOKIE_TEST_USER_2
+        notifications = @fa.notifications(false)[:new_favorites]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).not_to be_empty
+
+        notifications_include = @fa.notifications(true)[:new_favorites]
+        expect(notifications_include).to be_instance_of Array
+        expect(notifications_include).not_to be_empty
+
+        expect(notifications_include.length).to be > notifications.length
+
+        deleted = notifications_include - notifications
+
+        deleted.each do |deleted_fav|
+          expect(deleted_fav[:favorite_notification_id]).to eql("")
+          expect(deleted_fav[:name]).to eql("The favorite this notification was for has since been removed by the user")
+          expect(deleted_fav[:profile]).to eql("")
+          expect(deleted_fav[:profile_name]).to eql("")
+          expect(deleted_fav[:submission_id]).to eql("")
+          expect(deleted_fav[:submission_name]).to eql("The favorite this notification was for has since been removed by the user")
+          expect(deleted_fav[:posted]).to eql("")
+          expect(deleted_fav[:posted_at]).to eql("")
+        end
+      end
+    end
+
+    context 'journal notifications' do
+      it 'should handle zero new journals' do
+        @fa.login_cookie = COOKIE_TEST_USER_NO_NOTIFICATIONS
+        notifications = @fa.notifications(false)[:new_journals]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).to be_empty
+      end
+
+      it 'returns a list of new journal notifications' do
+        @fa.login_cookie = COOKIE_TEST_USER_3
+        notifications = @fa.notifications(false)[:new_journals]
+        expect(notifications).to be_instance_of Array
+        expect(notifications).not_to be_empty
+
+        notifications.each do |new_journal|
+          expect(new_journal[:journal_id]).to match(/[0-9]+/)
+          expect(new_journal[:title]).not_to be_blank
+          check_profile_link(new_journal)
+          check_date(new_journal[:posted], new_journal[:posted_at])
+        end
+      end
+    end
+  end
+
+  context 'when posting a new journal' do
+    it 'requires a login cookie' do
+      @fa.login_cookie = nil
+      expect { @fa.submit_journal("Do not post", "This journal should fail to post") }.to raise_error(FALoginError)
+    end
+
+    it 'fails if not given title' do
+      expect { @fa.submit_journal(nil, "No title journal") }.to raise_error(FAFormError)
+    end
+
+    it 'fails if not given description' do
+      expect { @fa.submit_journal("Title, no desc", nil) }.to raise_error(FAFormError)
+    end
+
+    it 'can post a new journal entry' do
+      @fa.login_cookie = COOKIE_TEST_USER_JOURNAL_DUMP
+      magic_key = (0...5).map { ('a'..'z').to_a[rand(26)] }.join
+      long_magic_key = (0...50).map { ('a'..'z').to_a[rand(26)] }.join
+      journal_title = "Automatically generated title - #{magic_key}"
+      journal_description = "Hello, this is an automatically generated journal.\n Magic key: #{long_magic_key}"
+
+      journal_resp = @fa.submit_journal(journal_title, journal_description)
+
+      expect(journal_resp[:url]).to match(/https:\/\/www.furaffinity.net\/journal\/[0-9]+\//)
+
+      # Get journal listing, ensure latest is this one
+      journals = @fa.journals(TEST_USER_JOURNAL_DUMP, 1)
+      expect(journals[0][:title]).to eql(journal_title)
+      expect(journals[0][:description]).to eql(journal_description.gsub("\n", "<br>\n"))
+      expect(journal_resp[:url]).to eql("https://www.furaffinity.net/journal/#{journals[0][:id]}/")
+    end
+  end
+
+  private
+
+  # noinspection RubyResolve
+  def check_submission(submission, blank_profile=false, blank_title=false)
+    # Check ID
+    expect(submission[:id]).to match(/^[0-9]+$/)
+    # Check title
+    if blank_title
+      expect(submission[:title]).to be_blank, "Title of submission #{submission[:id]} was not meant to be blank"
+    else
+      expect(submission[:title]).not_to be_blank
+    end
+    # Check thumbnail
+    check_thumbnail_link(submission[:thumbnail], submission[:id])
+    # Check link
+    check_submission_link(submission[:link], submission[:id])
+    # Check profile
+    if blank_profile
+      expect(submission[:name]).to be_blank
+      expect(submission[:profile]).to be_blank
+      expect(submission[:profile_name]).to be_blank
+    else
+      check_profile_link submission
+    end
+  end
+
+  def check_profile_link(item, watch_list=false)
+    expect(item[:name]).not_to be_blank
+    expect(item[watch_list ? :link : :profile]).to eql "https://www.furaffinity.net/user/#{item[:profile_name]}/"
+    expect(item[:profile_name]).to match(FAExport::Application::USER_REGEX)
+  end
+
+  def check_date(date_string, iso_string)
+    expect(date_string).not_to be_blank
+    expect(date_string).to match(/[A-Z][a-z]{2} [0-9]+[a-z]{2}, [0-9]{4} [0-9]{2}:[0-9]{2}/)
+    expect(iso_string).not_to be_blank
+    expect(iso_string).to eql(Time.parse(date_string + ' UTC').iso8601)
+  end
+
+  def check_avatar(avatar_link, username)
+    expect(avatar_link).to match(/^https:\/\/a.facdn.net\/[0-9]+\/#{username}.gif$/)
+  end
+
+  def check_submission_link(link, id)
+    expect(link).to match(/^https:\/\/www.furaffinity.net\/view\/#{id}\/?$/)
+  end
+
+  def check_thumbnail_link(link, id)
+    expect(link).to match(/^https:\/\/t.facdn.net\/#{id}@[0-9]{2,3}-[0-9]+.jpg$/)
+  end
+
+  def check_results_lists_are_similar(results1, result2)
+    results1_ids = results1.map{|result| result[:id]}
+    results2_ids = result2.map{|result| result[:id]}
+    intersection = results1_ids & results2_ids
+
+    threshold = [results1_ids.length, results2_ids.length].max * 0.9
+    expect(intersection.length).to be >= threshold
+  end
+
+  def check_results_lists_are_different(results1, results2)
+    results1_ids = results1.map{|result| result[:id]}
+    results2_ids = results2.map{|result| result[:id]}
+    intersection = results1_ids & results2_ids
+
+    threshold = [results1_ids.length, results2_ids.length].max * 0.1
+    expect(intersection.length).to be <= threshold
+  end
+end


### PR DESCRIPTION
Same as the notes PR, but now with some automated tests.

Text from that PR:
That was reasonably speedy.
Adds /notes/{folder} endpoints, and /note/{id} endpoints.

Things I'm not terribly confident on:
- Note rss feed saying a note is received, when it might not be following inbox
- Hash[string.to_sym] in notes to convert API name to FA name for notes folders
- ~My changes to fetch() to add extra_cookie argument~ (EDIT: tested, fixed)