### PR TITLE
Notes deleted account fix

### DIFF
--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -866,9 +866,11 @@ class Furaffinity
       if profile.nil?
         profile_link = nil
         profile_name = nil
+        user_deleted = true
       else
         profile_link = fa_url(profile["href"][1..-1])
         profile_name = last_path(profile["href"])
+        user_deleted = false
       end
       {
         note_id: note.at_css("input")["value"].to_i,
@@ -878,6 +880,7 @@ class Furaffinity
         name: name,
         profile: profile_link,
         profile_name: profile_name,
+        user_deleted: user_deleted,
         posted: date,
         posted_at: to_iso8601(date)
       }
@@ -899,16 +902,29 @@ class Furaffinity
     date = pick_date(note_table.at_css("span.popup_date"))
     description = note_table.at_css("td.text")
     desc_split = description.inner_html.split("—————————")
+    name = profile&.content
+    if profile.nil?
+      profile_link = nil
+      profile_name = nil
+      avatar = nil
+      user_deleted = true
+    else
+      profile_link = fa_url(profile["href"][1..-1])
+      profile_name = last_path(profile["href"])
+      avatar = "https#{note_table.at_css("img.avatar")["src"]}"
+      user_deleted = false
+    end
     {
       note_id: id,
       subject: note_header.at_css("em.title").content,
       is_inbound: is_inbound,
-      name: profile.content,
-      profile: fa_url(profile["href"][1..-1]),
-      profile_name: last_path(profile["href"]),
+      name: name,
+      profile: profile_link,
+      profile_name: profile_name,
+      user_deleted: user_deleted,
       posted: date,
       posted_at: to_iso8601(date),
-      avatar: "https#{note_table.at_css("img.avatar")["src"]}",
+      avatar: avatar,
       description: description.inner_html.strip,
       description_body: html_strip(desc_split.first.strip),
       preceding_notes: desc_split[1..-1].map do |note|

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -862,14 +862,22 @@ class Furaffinity
         is_inbound = profile_to.content.strip == "me"
         profile = is_inbound ? profile_from.at_css("a") : profile_to.at_css("a")
       end
+      name = profile&.content
+      if profile.nil?
+        profile_link = nil
+        profile_name = nil
+      else
+        profile_link = fa_url(profile["href"][1..-1])
+        profile_name = last_path(profile["href"])
+      end
       {
         note_id: note.at_css("input")["value"].to_i,
         subject: subject.at_css("a.notelink").content,
         is_inbound: is_inbound,
         is_read: subject.at_css("a.notelink.note-unread").nil?,
-        name: profile.content,
-        profile: fa_url(profile["href"][1..-1]),
-        profile_name: last_path(profile["href"]),
+        name: name,
+        profile: profile_link,
+        profile_name: profile_name,
         posted: date,
         posted_at: to_iso8601(date)
       }

--- a/lib/faexport/views/docs.md
+++ b/lib/faexport/views/docs.md
@@ -903,7 +903,8 @@ As deleted journal notifications are hidden on FA now, you cannot display these 
 
 Login cookie required.
 
-Lists the notes in a specified folder. Specified folders can be `inbox`, `outbox`, `unread`, `archive`, `trash`, `high`, `medium`, or `low`.
+Lists the notes in a specified folder. Specified folders can be `inbox`, `outbox`, `unread`, `archive`, `trash`, `high`, `medium`, or `low`.  
+If the user the note is to/from has been deleted, "name", "profile", and "profile_name" will be null, and "user_deleted" will be true.
 
 ~~~json
 [
@@ -915,6 +916,7 @@ Lists the notes in a specified folder. Specified folders can be `inbox`, `outbox
     "name": "John Oliver",
     "profile": "https://furaffinity.net/user/john_oliver/",
     "profile_name": "john_oliver",
+    "user_deleted": false,
     "posted": "on May 3rd, 2019 01:04 PM",
     "posted_at": "2019-05-03T13:04:00Z"
   },
@@ -928,7 +930,8 @@ Lists the notes in a specified folder. Specified folders can be `inbox`, `outbox
 
 Login cookie required.
 
-Views a specific note.
+Views a specific note.  
+If the user the note is to/from has been deleted, "name", "profile", and "profile_name" will be null, and "user_deleted" will be true.
 
 ~~~json
 {
@@ -938,6 +941,7 @@ Views a specific note.
   "name": "John Oliver",
   "profile": "https://furaffinity.net/user/john_oliver/",
   "profile_name": "john_oliver",
+  "user_deleted": false,
   "posted": "on May 3rd, 2019 01:04 PM",
   "posted_at": "2019-05-03T13:04:00Z",
   "description": "Not really. How are you?\n\n______<snip>",


### PR DESCRIPTION
Turns out that if you get a note from a deleted account, it broke the notes endpoints. This PR should fix that, and add a "user_deleted" property to representation of notes in both those endpoints, to tell you if the user has been deleted.