### PR TITLE
Remove login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ Changelog for FAExport API, should include entries for these types of changes:
 
 Format inspired by https://keepachangelog.com/en/1.0.0/
 
+## [v2022.01.2] - 2022-01-12
+
+### Security
+
+- Fixed session leak issue in authenticated endpoints.
+
+### Removed
+
+- Removed deprecated and broken login() method, and ability to configure via username and password
+
 ## [v2022.01.1] - 2022-01-05
 
 ### Added

--- a/lib/faexport.rb
+++ b/lib/faexport.rb
@@ -237,8 +237,6 @@ module FAExport
       @cache = RedisCache.new(FAExport.config[:redis_url],
                               FAExport.config[:cache_time],
                               FAExport.config[:cache_time_long])
-      @fa = Furaffinity.new(@cache)
-
       @system_cookie = FAExport.config[:cookie] || @cache.redis.get("login_cookie")
 
       super(app)
@@ -306,6 +304,7 @@ module FAExport
     before do
       env["rack.errors"] = error_log
       @user_cookie = request.env["HTTP_FA_COOKIE"]
+      @fa = Furaffinity.new(@cache)
       if @user_cookie
         if @user_cookie =~ COOKIE_REGEX
           @fa.login_cookie = @user_cookie.strip

--- a/lib/faexport.rb
+++ b/lib/faexport.rb
@@ -226,8 +226,6 @@ module FAExport
       FAExport.config[:cache_time] ||= 30 # 30 seconds
       FAExport.config[:cache_time_long] ||= 86_400 # 1 day
       FAExport.config[:redis_url] ||= (ENV["REDIS_URL"] || ENV["REDISTOGO_URL"])
-      FAExport.config[:username] ||= ENV["FA_USERNAME"]
-      FAExport.config[:password] ||= ENV["FA_PASSWORD"]
       FAExport.config[:cookie] ||= ENV["FA_COOKIE"]
       FAExport.config[:rss_limit] ||= 10
       FAExport.config[:content_types] ||= {
@@ -242,10 +240,6 @@ module FAExport
       @fa = Furaffinity.new(@cache)
 
       @system_cookie = FAExport.config[:cookie] || @cache.redis.get("login_cookie")
-      unless @system_cookie
-        @system_cookie = @fa.login(FAExport.config[:username], FAExport.config[:password])
-        @cache.redis.set("login_cookie", @system_cookie)
-      end
 
       super(app)
     end

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -262,21 +262,6 @@ class Furaffinity
     @safe_for_work = false
   end
 
-  def login(username, password)
-    response = post(
-      "/login/",
-      {
-        "action" => "login",
-        "retard_protection" => "1",
-        "name" => username,
-        "pass" => password,
-        "login" => "Login to Furaffinity"
-      }
-    )
-    "b=#{response["set-cookie"][/b=([a-z0-9\-]+);/, 1]}; "\
-    "a=#{response["set-cookie"][/a=([a-z0-9\-]+);/, 1]}"
-  end
-
   def home
     html = fetch("")
     groups = html.css("#frontpage > .old-table-emulation")

--- a/tests/integration/browse_spec.rb
+++ b/tests/integration/browse_spec.rb
@@ -11,7 +11,8 @@ describe "FA parser browse endpoint" do
   before do
     config = File.exist?("settings-test.yml") ? YAML.load_file("settings-test.yml") : {}
     @app = FAExport::Application.new(config).instance_variable_get(:@instance)
-    @fa = @app.instance_variable_get(:@fa)
+    cache = @app.instance_variable_get(:@cache)
+    @fa = Furaffinity.new(cache)
     @fa.login_cookie = COOKIE_DEFAULT
   end
 

--- a/tests/integration/fa_parsing_spec.rb
+++ b/tests/integration/fa_parsing_spec.rb
@@ -33,7 +33,8 @@ describe "FA parser" do
   before do
     config = File.exist?("settings-test.yml") ? YAML.load_file("settings-test.yml") : {}
     @app = FAExport::Application.new(config).instance_variable_get(:@instance)
-    @fa = @app.instance_variable_get(:@fa)
+    cache = @app.instance_variable_get(:@cache)
+    @fa = Furaffinity.new(cache)
     @fa.login_cookie = COOKIE_DEFAULT
   end
 

--- a/tests/integration/search_spec.rb
+++ b/tests/integration/search_spec.rb
@@ -11,7 +11,8 @@ describe "FA parser search endpoint" do
   before do
     config = File.exist?("settings-test.yml") ? YAML.load_file("settings-test.yml") : {}
     @app = FAExport::Application.new(config).instance_variable_get(:@instance)
-    @fa = @app.instance_variable_get(:@fa)
+    cache = @app.instance_variable_get(:@cache)
+    @fa = Furaffinity.new(cache)
     @fa.login_cookie = COOKIE_DEFAULT
   end
 


### PR DESCRIPTION
Removing the login() method, which hasn't worked for years. This also allows us to create the @fa object for each request, avoiding session leaks