### PR TITLE
Fixed make deploy* targets & added key param for securing user cookies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,13 +66,13 @@ publish: VERSION clean
 	docker push $(DOCKER_HUB_NAME):latest
 
 deploy: FA_COOKIE
-	FA_COOKIE=$(FA_COOKIE) PORT=${PORT} VERSION=${CONTAINER_TAG} APP_ENV=production docker-compose up
+	FA_COOKIE="$(FA_COOKIE)" PORT=${PORT} VERSION=${CONTAINER_TAG} APP_ENV=production docker-compose up
 
 deploy_bg: FA_COOKIE
-	FA_COOKIE=$(FA_COOKIE) PORT=${PORT} VERSION=${CONTAINER_TAG} APP_ENV=production docker-compose up -d
+	FA_COOKIE="$(FA_COOKIE)" PORT=${PORT} VERSION=${CONTAINER_TAG} APP_ENV=production docker-compose up -d
 
 deploy_bypass: FA_COOKIE
-	FA_COOKIE=$(FA_COOKIE) PORT=${PORT} VERSION=${CONTAINER_TAG} APP_ENV=production docker-compose -f docker-compose.yml -f docker-compose-cfbypass.yml up
+	FA_COOKIE="$(FA_COOKIE)" PORT=${PORT} VERSION=${CONTAINER_TAG} APP_ENV=production docker-compose -f docker-compose.yml -f docker-compose-cfbypass.yml up
 
 clean_docker:
 	docker-compose down -v --rmi all --remove-orphans || true

--- a/lib/faexport.rb
+++ b/lib/faexport.rb
@@ -260,7 +260,7 @@ module FAExport
       end
 
       def ensure_login!
-        return if @user_cookie
+        return if !@user_cookie
 
         raise FALoginCookieError.new(
           'You must provide a valid login cookie in the header "FA_COOKIE".'\

--- a/lib/faexport.rb
+++ b/lib/faexport.rb
@@ -233,7 +233,6 @@ module FAExport
       FAExport.config[:cache_time_long] ||= 86_400 # 1 day
       FAExport.config[:redis_url] ||= (ENV["REDIS_URL"] || ENV["REDISTOGO_URL"])
       FAExport.config[:cookie] ||= ENV["FA_COOKIE"]
-      FAExport.config[:key] ||= ENV["key"]
       FAExport.config[:rss_limit] ||= 10
       FAExport.config[:content_types] ||= {
         "json" => "application/json",
@@ -260,20 +259,13 @@ module FAExport
         content_type FAExport.config[:content_types][type], "charset" => "utf-8"
       end
 
-      def ensure_login!        
-        if @user_cookie
-          raise FALoginCookieError.new(
-          'You must provide a valid login cookie in the header "FA_COOKIE".'\
-          "Please note this is a header, not a cookie. #{@user_cookie}"
-        )
-        end
+      def ensure_login!
+        return if @user_cookie
 
-        if !(params[:key] == FAExport.config[:key])
         raise FALoginCookieError.new(
-          "Unauthorised key provided."
+          'You must provide a valid login cookie in the header "FA_COOKIE".'\
+          "Please note this is a header, not a cookie."
         )
-        end
-        return true
       end
 
       def record_metrics(endpoint, format, &block)

--- a/lib/faexport.rb
+++ b/lib/faexport.rb
@@ -233,6 +233,7 @@ module FAExport
       FAExport.config[:cache_time_long] ||= 86_400 # 1 day
       FAExport.config[:redis_url] ||= (ENV["REDIS_URL"] || ENV["REDISTOGO_URL"])
       FAExport.config[:cookie] ||= ENV["FA_COOKIE"]
+      FAExport.config[:key] ||= ENV["key"]
       FAExport.config[:rss_limit] ||= 10
       FAExport.config[:content_types] ||= {
         "json" => "application/json",
@@ -259,13 +260,20 @@ module FAExport
         content_type FAExport.config[:content_types][type], "charset" => "utf-8"
       end
 
-      def ensure_login!
-        return if @user_cookie
-
-        raise FALoginCookieError.new(
+      def ensure_login!        
+        if @user_cookie
+          raise FALoginCookieError.new(
           'You must provide a valid login cookie in the header "FA_COOKIE".'\
-          "Please note this is a header, not a cookie."
+          "Please note this is a header, not a cookie. #{@user_cookie}"
         )
+        end
+
+        if !(params[:key] == FAExport.config[:key])
+        raise FALoginCookieError.new(
+          "Unauthorised key provided."
+        )
+        end
+        return true
       end
 
       def record_metrics(endpoint, format, &block)


### PR DESCRIPTION
Added double quotes around env vars in Makefile so that passed vars are included properly.

Added `key` support in URL query parameter or `settings.yml` for securing endpoints where login cookie is required.