### PR TITLE
Allow flexibility in number of results in browse pages

### DIFF
--- a/lib/faexport/views/docs.md
+++ b/lib/faexport/views/docs.md
@@ -142,7 +142,7 @@ Fetches all the recent uploads on the browse page.
 The following parameters can be provided:
 
 * **page**: Page of results to display.  Defaults to: `1`.
-* **perpage**: How many results to display per page.  Can be one of: `24`, `48` or `72`.  Defaults to: `72`.
+* **perpage**: How many results to display per page. Can be one of: `24`, `48` or `72`.  Defaults to: `72`. This is really a maximum amount, as FA will sometimes return a couple fewer results.
 * **rating**: what rating levels are included.  Can be any of: `general`, `mature` and `adult` separated by commas.  Defaults to: `general,mature,adult`.
 
 The API does not yet allow specifying category, type, species or gender, as FA requires hard coding these by number.
@@ -667,7 +667,7 @@ The following parameters can be provided:
 
 * **q**: Words to search for.
 * **page**: Page of results to display.  Defaults to: `1`.
-* **perpage**: How many results to display per page.  Can be one of: `24`, `48` or `72`.  Defaults to: `72`.
+* **perpage**: How many results to display per page.  Can be one of: `24`, `48` or `72`.  Defaults to: `72`. This is really a maximum amount, as FA will sometimes return a couple fewer results.
 * **order_by**: How the results should be ordered.  Can be one of: `relevancy`, `date` or `popularity`.  Defaults to: `date`.
 * **order_direction**: if results should be ordered in ascending or descending order.  Can be one of: `asc` or `desc`.  Defaults to: `desc`.
 * **range**: How far in the past should results be loaded from.  Can be one of: `1day`, `3days`, `7days`, `30days`, `90days`, `1year`, `3years`, `5years` or `all`. Defaults to: `all`.

--- a/tests/integration/browse_spec.rb
+++ b/tests/integration/browse_spec.rb
@@ -65,7 +65,7 @@ describe "FA parser browse endpoint" do
         submissions.each do |submission|
           expect(submission).to be_valid_submission
         end
-        expect(submissions.length).to eql(72)
+        expect(submissions.length).to be_between(68, 72)
       end
     end
 
@@ -74,9 +74,9 @@ describe "FA parser browse endpoint" do
       submissions48 = browse_with_retry({ "perpage" => "48" })
       submissions72 = browse_with_retry({ "perpage" => "72" })
 
-      expect(submissions24.length).to eql(24)
-      expect(submissions48.length).to eql(48)
-      expect(submissions72.length).to eql(72)
+      expect(submissions24.length).to be_between(20, 24)
+      expect(submissions48.length).to be_between(44, 48)
+      expect(submissions72.length).to be_between(68, 72)
     end
 
     it "can specify ratings to display, and honours that selection" do


### PR DESCRIPTION
This should reduce the amount of spurious failing regression tests. It seems that FA doesn't always return as many submissions as you request, and it might be a few less.