### PR TITLE
 Fail tests early if config isn't set

### DIFF
--- a/tests/integration/browse_spec.rb
+++ b/tests/integration/browse_spec.rb
@@ -8,6 +8,10 @@ require "rspec"
 COOKIE_DEFAULT = ENV["test_cookie"]
 
 describe "FA parser browse endpoint" do
+  before(:all) do
+    expect(COOKIE_DEFAULT).not_to be_empty, "Test cookie needs to be set for testing"
+  end
+
   before do
     config = File.exist?("settings-test.yml") ? YAML.load_file("settings-test.yml") : {}
     @app = FAExport::Application.new(config).instance_variable_get(:@instance)

--- a/tests/integration/fa_parsing_spec.rb
+++ b/tests/integration/fa_parsing_spec.rb
@@ -30,6 +30,10 @@ COOKIE_TEST_USER_JOURNAL_DUMP = COOKIE_TEST_USER_3
 COOKIE_NOT_CLASSIC = ENV["test_cookie_not_classic"]
 
 describe "FA parser" do
+  before(:all) do
+    expect(COOKIE_DEFAULT).not_to be_empty, "Test cookie needs to be set for testing"
+  end
+
   before do
     config = File.exist?("settings-test.yml") ? YAML.load_file("settings-test.yml") : {}
     @app = FAExport::Application.new(config).instance_variable_get(:@instance)

--- a/tests/integration/search_spec.rb
+++ b/tests/integration/search_spec.rb
@@ -8,6 +8,10 @@ require "rspec"
 COOKIE_DEFAULT = ENV["test_cookie"]
 
 describe "FA parser search endpoint" do
+  before(:all) do
+    expect(COOKIE_DEFAULT).not_to be_empty, "Test cookie needs to be set for testing"
+  end
+
   before do
     config = File.exist?("settings-test.yml") ? YAML.load_file("settings-test.yml") : {}
     @app = FAExport::Application.new(config).instance_variable_get(:@instance)

--- a/tests/system_spec.rb
+++ b/tests/system_spec.rb
@@ -11,6 +11,10 @@ COOKIE_TEST_USER_2 = ENV["test_cookie_user_2"]
 SERVER_URL = ENV["server_url"]
 
 describe "FA export server" do
+  before(:all) do
+    expect(COOKIE_DEFAULT).not_to be_empty, "Test cookie needs to be set for testing"
+  end
+
   def fetch_with_retry(path, cookie: nil, check_status: true)
     wait_between_tries = 5
     retries = 0


### PR DESCRIPTION
Just, check if the test cookie is set before running any tests, so they fail fast and clear if they're not set