### PR TITLE
Strip null bytes from pages

### DIFF
--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -1165,7 +1165,7 @@ class Furaffinity
       end
     end
 
-    html = Nokogiri::HTML(raw.encode("UTF-8", invalid: :replace, undef: :replace))
+    html = Nokogiri::HTML(raw.encode("UTF-8", invalid: :replace, undef: :replace).delete("\000"))
 
     # Check for errors, and raise any that apply
     check_errors(html, url)

--- a/tests/integration/fa_parsing_spec.rb
+++ b/tests/integration/fa_parsing_spec.rb
@@ -710,6 +710,12 @@ describe "FA parser" do
       expect(submission).to have_key(:thumbnail)
       expect(submission[:thumbnail]).not_to be_nil
     end
+
+    it "should remove null bytes" do
+      submission = @fa.submission("641877")
+      expect(submission).to have_key(:description)
+      expect(submission[:description]).not_to include("\000")
+    end
   end
 
   context "when updating favorite status of a submission" do


### PR DESCRIPTION
FA should really be doing this, but I'm consistently finding submissions with null bytes all through them. Especially story submissions. I guess folks copy paste UTF-16 files into FA, and FA just takes that and serves it as UTF-8.

I think the API should just strip all the null bytes out at parse time, solves a lot of problems