### PR TITLE
Fix deleted comment handling

### DIFF
--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -1328,9 +1328,15 @@ class Furaffinity
           is_deleted: false
         }
       elsif include_hidden
+        bold_text = comment.at_css("strong")
+        comment_text = if bold_text
+                         bold_text.content
+                       else
+                         comment.at_css(".block__deleted_content").content
+                       end
         {
           id: id,
-          text: comment.at_css("strong").content,
+          text: comment_text,
           reply_to: reply_to,
           reply_level: reply_level,
           is_deleted: true

--- a/tests/integration/fa_parsing_spec.rb
+++ b/tests/integration/fa_parsing_spec.rb
@@ -933,7 +933,7 @@ describe "FA parser" do
         expect(comments).to be_instance_of(Array)
         expect(comments).to satisfy("be longer than other list") { |n| n.length > comments_not_deleted.length}
         # Find and check the deleted comment
-        deleted_comment = comment.find { |comment| comment[:id] == deleted_comment_id}
+        deleted_comment = comments.find { |comment| comment[:id] == deleted_comment_id}
         expect(deleted_comment).not_to be_empty
         expect(deleted_comment[:text]).to eql("[deleted]")
       end

--- a/tests/integration/fa_parsing_spec.rb
+++ b/tests/integration/fa_parsing_spec.rb
@@ -923,6 +923,21 @@ describe "FA parser" do
         expect(comments[0][:is_deleted]).to be true
       end
 
+      it "handles non-bold deleted comments when specified" do
+        submission_id = "49714673"
+        deleted_comment_id = "168509004"
+        comments_not_deleted = @fa.submission_comments(submission_id, false)
+        expect(comments_not_deleted).to be_instance_of Array
+        # Ensure comments appear when viewing deleted
+        comments = @fa.submission_comments(submission_id, true)
+        expect(comments).to be_instance_of(Array)
+        expect(comments).to satisfy("be longer than other list") { |n| n.length > comments_not_deleted.length}
+        # Find and check the deleted comment
+        deleted_comment = comment.find { |comment| comment[:id] == deleted_comment_id}
+        expect(deleted_comment).not_to be_empty
+        expect(deleted_comment[:text]).to eql("[deleted]")
+      end
+
       it "fails when given non-existent submission" do
         expect { @fa.submission_comments("16437650", false) }.to raise_error(FANotFoundError)
       end


### PR DESCRIPTION
Seems that FA now has some comments which get deleted with just a "[deleted]" message, not in bold. This breaks the current parsing, so here's a PR to fix that