### PR TITLE
Adding HTTP basic auth option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,15 @@ You may want to do this in a private browsing session as logging out of your acc
 the cookie and break the scraper.
 This cookie must be for an account that is set to view the site in classic mode. Modern style cannot be parsed by this API.
 
-To authenticate with the API, you will need to provide that string in the FA_COOKIE header. (Header. Not a cookie)
+To authenticate with the API, you will need to provide that string in the FA_COOKIE header. (Header. Not a cookie).
+
+Another option, particularly for the authenticated RSS feeds, is to use HTTP basic auth, using the username "ab", and
+the password being the a and b cookie values, concatenated with a semi-colon between them. Like so:
+```uri
+https://ab:b1b985c4-d73e-492a-a830-ad238a3693ef;3a485360-d203-4a38-97e8-4ff7cdfa244c@faexport.spangle.org.uk/notifications/submissions.rss
+```
+You *must not* share such RSS feed links with others though, as your FA cookies are encoded into the URL, and could be
+used to access your account.
 
 
 ## Development Setup

--- a/lib/faexport.rb
+++ b/lib/faexport.rb
@@ -1068,7 +1068,7 @@ module FAExport
         when FANoTitleError     then 500
         when FAStyleError       then 400
         when FAGuestAccessError then 403  # Shouldn't reach the user really, as login error should cover it
-        when FALoginCookieError then 400
+        when FALoginCookieError then 401
         when FANotFoundError    then 404
         when FAContentFilterError then 403
         when FANoUserError      then 404
@@ -1080,6 +1080,10 @@ module FAExport
         else 500
         end
       )
+
+      if err.is_a? FALoginCookieError
+        headers['WWW-Authenticate'] = 'Basic realm="Restricted Endpoint"'
+      end
 
       JSON.pretty_generate error: err.message, url: err.url
     end

--- a/lib/faexport/public/css/faexport.css
+++ b/lib/faexport/public/css/faexport.css
@@ -10,7 +10,7 @@ dd {
     margin: 5px 20px;
 }
 
-#boxes input {
+#boxes input, #boxes_auth input {
     width: 300px;
     padding: 10px;
     font-size: 16px;

--- a/lib/faexport/public/js/faexport.js
+++ b/lib/faexport/public/js/faexport.js
@@ -1,19 +1,21 @@
 'use strict';
 
 $(function() {
-    function linkFormat(dataFormat, name, id) {
+    function linkFormat(dataFormat, name, id, cookie_a, cookie_b) {
         const base = window.location.origin;
+        const cookie_base = `${window.location.protocol}//ab:${cookie_a};${cookie_b}@${window.location.host}`;
         return dataFormat
             .replace('{name}', name)
             .replace('{id}', id)
-            .replace('{base}', base);
+            .replace('{base}', base)
+            .replace('{cookie_base}', cookie_base);
     }
 
-    function showLink(linkElement, name, id) {
+    function showLink(linkElement, name, id, cookie_a, cookie_b) {
         console.log("Show link");
         const dataFormat = linkElement.attr('data-format');
-        const address = linkFormat(dataFormat, encodeURI(name), id);
-        const text = linkFormat(dataFormat, name, id);
+        const address = linkFormat(dataFormat, encodeURI(name), id, cookie_a, cookie_b);
+        const text = linkFormat(dataFormat, name, id, cookie_a, cookie_b);
         linkElement.removeClass("disabled");
         linkElement.attr('href', address);
         linkElement.text(text);
@@ -22,34 +24,36 @@ $(function() {
     function hideLink(linkElement) {
         console.log("Hide link");
         const base = window.location.origin;
+        const cookie_base = `${window.location.protocol}//ab:{cookie_a};{cookie_b}@${window.location.host}`
         linkElement.addClass("disabled");
         linkElement.removeAttr('href');
-        linkElement.text(linkElement.attr('data-format').replace("{base}", base));
+        linkElement.text(linkElement.attr('data-format')
+            .replace("{base}", base)
+            .replace("{cookie_base}", cookie_base)
+        );
     }
 
     function update() {
         console.log("Update");
         const name = $('#boxes #name').val();
         const id = $('#boxes #id').val();
+        const cookie_a = $('#boxes_auth #cookie_a').val();
+        const cookie_b = $('#boxes_auth #cookie_b').val();
         $('.resource').each(function() {
-            if ($(this).attr('data-format').includes("{name}")) {
-                if ($(this).attr('data-format').includes("{id}")) {
-                    (name && id) ? showLink($(this), name, id) : hideLink($(this));
-                } else {
-                    (name) ? showLink($(this), name, id) : hideLink($(this));
-                }
-            } else {
-                if ($(this).attr('data-format').includes("{id}")) {
-                    (id) ? showLink($(this), name, id) : hideLink($(this));
-                } else {
-                    showLink($(this), name, id);
-                }
-            }
+            const data_format = $(this).attr('data-format');
+            const checks = [
+                !data_format.includes("{name}") || Boolean(name),
+                !data_format.includes("{id}") || Boolean(id),
+                !data_format.includes("{cookie_base}") || Boolean(cookie_a && cookie_b),
+            ];
+            checks.every(Boolean) ? showLink($(this), name, id, cookie_a, cookie_b) : hideLink($(this));
         });
     }
 
     $('#name').on('input propertychange paste', update);
     $('#id').on('input propertychange paste', update);
+    $('#cookie_a').on('input propertychange paste', update);
+    $('#cookie_b').on('input propertychange paste', update);
     $('#name').focus();
     update();
 });

--- a/lib/faexport/views/docs.md
+++ b/lib/faexport/views/docs.md
@@ -10,7 +10,8 @@ Please send any questions, comments or ramblings to [deer@spangle.org.uk](mailto
 When accessing routes that view or modify account specific data,
 you will need to provide a login cookie in the header `FA_COOKIE`.  
 The cookie `a` and `b` values can be obtained by checking your browser's storage inspector while on any FA page.  
-The storage inspector can be opened by pressing `Shift+F9` on Firefox, and on Chrome, by opening the developer tools with `F12` and then selecting the "Application" tab, and then "Cookies".  
+The storage inspector can be opened by pressing `Shift+F9` on Firefox, and on Chrome, by opening the developer tools
+with `F12` and then selecting the "Application" tab, and then "Cookies".  
 You may want to do this in a private browsing session as logging out of your account will invalidate
 the cookie and break the scraper.
 
@@ -19,6 +20,16 @@ The resulting FA_COOKIE header string should look something like this:
 ```
 "b=3a485360-d203-4a38-97e8-4ff7cdfa244c; a=b1b985c4-d73e-492a-a830-ad238a3693ef"
 ```
+
+Another option in use-cases where you cannot specify custom headers, such as loading RSS feeds into a feed reader, is to
+use HTTP basic auth. In this case you can specify a username of "ab", and specify the value of your "a" and "b" cookies,
+joined with a semicolon, as the password.
+For example:
+```uri
+https://ab:b1b985c4-d73e-492a-a830-ad238a3693ef;3a485360-d203-4a38-97e8-4ff7cdfa244c@faexport.spangle.org.uk/notifications/others.rss
+```
+In this case, you must ensure not to share the URL with 3rd parties whom you do not trust, as it contains your FA
+authentication cookies, and can be used to gain access to your account.
 
 
 ## Status Codes

--- a/lib/faexport/views/index.haml
+++ b/lib/faexport/views/index.haml
@@ -55,30 +55,41 @@
       - %w(json xml).each do |type|
         %a.resource{href: '#', target: '_blank', :'data-format' => "{base}/#{resource}/{id}/comments.#{type}"}
         %br
+  %br
+  %hr
+#boxes_auth
+  %h2 Login cookie-required endpoints
+  Enter FA cookie values:
+  %br
+  a =
+  %input#cookie_a{type: 'text', autocomplete: 'off'}
+  ;b =
+  %input#cookie_b{type: 'text', autocomplete: 'off'}
+%dl#links_auth
   %dt New submission notifications (login cookie required)
   %dd
     - %w(json xml rss).map do |type|
-      %a.resource{href: '#', target: '_blank', :'data-format' => "{base}/notifications/submissions.#{type}"}
+      %a.resource{href: '#', target: '_blank', :'data-format' => "{cookie_base}/notifications/submissions.#{type}"}
       %br
   %dt Notifications (login cookie required)
   %dd
     - %w(json xml).map do |type|
-      %a.resource{href: '#', target: '_blank', :'data-format' => "{base}/notifications/others.#{type}"}
+      %a.resource{href: '#', target: '_blank', :'data-format' => "{cookie_base}/notifications/others.#{type}"}
       %br
   - %w(watches submission_comments journal_comments shouts favorites journals).map do |notification_type|
     %dd
-      %a.resource{href: '#', target: '_blank', :'data-format' => "{base}/notifications/#{notification_type}.rss"}
+      %a.resource{href: '#', target: '_blank', :'data-format' => "{cookie_base}/notifications/#{notification_type}.rss"}
       %br
   %dt Notes (login cookie required)
   %dd
     - %w(json xml rss).map do |type|
       - %w(inbox unread outbox high medium low archive trash).map do |folder|
         %dd
-          %a.resource{href: '#', target: '_blank', :'data-format' => "{base}/notes/#{folder}.#{type}"}
+          %a.resource{href: '#', target: '_blank', :'data-format' => "{cookie_base}/notes/#{folder}.#{type}"}
           %br
   %dt Note view (login cookie required)
   %dd
     - %w(json xml).map do |type|
       %dd
-        %a.resource{href: '#', target: '_blank', :'data-format' => "{base}/note/{id}.#{type}"}
+        %a.resource{href: '#', target: '_blank', :'data-format' => "{cookie_base}/note/{id}.#{type}"}
         %br

--- a/tests/system_spec.rb
+++ b/tests/system_spec.rb
@@ -18,18 +18,20 @@ describe "FA export server" do
   def fetch_with_retry(path, cookie: nil, check_status: true, user: nil, password: nil)
     wait_between_tries = 5
     retries = 0
-    authority = SERVER_URL
+    url = "#{SERVER_URL}/#{path}"
+    user_info = nil
     if user and password
-      scheme, host = SERVER_URL.split("//")
-      authority = "#{scheme}//#{user}:#{password}@#{host}"
+      user_info = [user, password]
     end
-    url = "#{authority}/#{path}"
 
     begin
       if cookie
-        URI.parse(url).open({ "FA_COOKIE" => cookie.to_s })
+        URI.parse(url).open(
+          { "FA_COOKIE" => cookie.to_s },
+          http_basic_authentication: user_info
+        )
       else
-        URI.parse(url).open
+        URI.parse(url).open(http_basic_authentication: user_info)
       end
     rescue OpenURI::HTTPError => e
       raise if check_status

--- a/tests/system_spec.rb
+++ b/tests/system_spec.rb
@@ -100,7 +100,7 @@ describe "FA export server" do
     it "returns an error if cookie is not given" do
       resp = fetch_with_retry("/notifications/others.json", check_status: false)
       expect(resp.status[0]).to eq("401")
-      expect(resp.headers["WWW-Authenticate"]).not_to be_falsey
+      expect(resp.meta["www-authenticate"]).not_to be_falsey
       body = resp.read
       expect(body).not_to be_empty
       data = JSON.parse(body)

--- a/tests/system_spec.rb
+++ b/tests/system_spec.rb
@@ -21,7 +21,7 @@ describe "FA export server" do
     authority = SERVER_URL
     if user and password
       scheme, host = SERVER_URL.split("//")
-      authority = "#{scheme}://#{user}:#{password}@#{host}"
+      authority = "#{scheme}//#{user}:#{password}@#{host}"
     end
     url = "#{authority}/#{path}"
 

--- a/tests/system_spec.rb
+++ b/tests/system_spec.rb
@@ -26,12 +26,11 @@ describe "FA export server" do
 
     begin
       if cookie
-        URI.parse(url).open(
-          { "FA_COOKIE" => cookie.to_s },
-          :http_basic_authentication => user_info
-        )
-      else
+        URI.parse(url).open({ "FA_COOKIE" => cookie.to_s })
+      elsif user_info
         URI.parse(url).open(:http_basic_authentication => user_info)
+      else
+        URI.parse(url).open
       end
     rescue OpenURI::HTTPError => e
       raise if check_status

--- a/tests/system_spec.rb
+++ b/tests/system_spec.rb
@@ -28,10 +28,10 @@ describe "FA export server" do
       if cookie
         URI.parse(url).open(
           { "FA_COOKIE" => cookie.to_s },
-          http_basic_authentication: user_info
+          :http_basic_authentication => user_info
         )
       else
-        URI.parse(url).open(http_basic_authentication: user_info)
+        URI.parse(url).open(:http_basic_authentication => user_info)
       end
     rescue OpenURI::HTTPError => e
       raise if check_status


### PR DESCRIPTION
I've gotten a few emails asking how to use the authenticated RSS feeds, and .. I've not been too sure.
The technical answer is to specify your cookies in the `FA_COOKIES` header, but I've never seen an RSS feed reader that supports that except for the one I built myself.

So I spent some time researching RSS feed readers, and the best practice for authenticated RSS feeds, and this seems the best option. (The only other option I see is putting the cookie values in a get parameter)

So, this PR adds the option to use HTTP basic auth on all authenticated endpoints. It changes the homepage to add some input boxes where you can enter the values of your `a` and `b` cookies, and it'll tell you the authenticated feed URLs, which you should be able to put into your RSS reader!
I'm not certain whether all RSS feed readers will support basic auth, but some of them certainly do.

