### PR TITLE
Fix favourites tests

### DIFF
--- a/tests/integration/fa_parsing_spec.rb
+++ b/tests/integration/fa_parsing_spec.rb
@@ -450,7 +450,7 @@ describe "FA parser" do
         expect(favs1).to be_instance_of Array
         expect(favs1.length).to be 72
         favs_overlap.each do |fav|
-          expect(fav[:fav_id]).to be > overlap_fav_id
+          expect(fav[:fav_id].to_i).to be > overlap_fav_id.to_i
         end
       end
     end

--- a/tests/integration/fa_parsing_spec.rb
+++ b/tests/integration/fa_parsing_spec.rb
@@ -434,7 +434,7 @@ describe "FA parser" do
         expect(favs_next.length).to be > (72 - 58)
         expect(favs_next[0][:fav_id]).to eql(fav_id_next)
         favs_next.each do |fav|
-          expect(fav[:fav_id]).to be < fav_id
+          expect(fav[:fav_id].to_i).to be < fav_id.to_i
         end
       end
 


### PR DESCRIPTION
Regression tests are failing because fav_ids are being compared as strings instead of ints, in the next/prev favid tests. This fixes that