### PR TITLE
Handle "pending deletion" error

### DIFF
--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -1391,8 +1391,8 @@ class Furaffinity
     end
 
     # Handle "system message" type errors
-    maintable_head = html.at_css("table.maintable td.cat b")
-    if !maintable_head.nil? && maintable_head.content == "System Message"
+    maintable_head = p html.at_css("table.maintable td.cat")
+    if !maintable_head.nil? && (p maintable_head.content.strip) == "System Message"
       maintable_content = html.at_css("table.maintable td.alt1").content
       # Handle disabled accounts
       if maintable_content.include?("has voluntarily disabled access to their account and all of its contents.")
@@ -1409,6 +1409,11 @@ class Furaffinity
       # Handle content filter errors, accessing a nsfw submission with a sfw profile
       if maintable_content.include?("You are not allowed to view this image due to the content filter settings.")
         raise FAContentFilterError.new(url)
+      end
+
+      # Handle page is pending deletion
+      if maintable_content.include?("The page you are trying to reach is currently pending deletion")
+        raise FANotFoundError.new(url)
       end
     end
   end

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -1391,8 +1391,8 @@ class Furaffinity
     end
 
     # Handle "system message" type errors
-    maintable_head = p html.at_css("table.maintable td.cat")
-    if !maintable_head.nil? && (p maintable_head.content.strip) == "System Message"
+    maintable_head = html.at_css("table.maintable td.cat")
+    if !maintable_head.nil? && maintable_head.content.strip == "System Message"
       maintable_content = html.at_css("table.maintable td.alt1").content
       # Handle disabled accounts
       if maintable_content.include?("has voluntarily disabled access to their account and all of its contents.")

--- a/lib/faexport/views/docs.md
+++ b/lib/faexport/views/docs.md
@@ -35,8 +35,8 @@ authentication cookies, and can be used to gain access to your account.
 ## Errors and status codes
 
 In the case of an error, the response will be returned as json with an `error_type` field giving an error type you can
-match against in your code, an `error` field giving details of what happened and a `url` field that includes any FA url
-that the error originated from.
+match against in your code, an `error` field giving details of what happened and, optionally, a `url` field that
+includes any FA url that the error originated from.
 
 ~~~json
 {


### PR DESCRIPTION
Turns out there's an error page which says:
> The page you are trying to reach is currently pending deletion by a request from the administration.

I hadn't seen this before, and the API was responding with just:
```
{
  "error_type": "unknown",
  "error": "FAExport encountered an internal error"
}
```

So lets handle that better.
I can't add an integration test because any page pending deletion, is probably pending deletion for a temporary amount of time, so any test would probably be unreliable in the longer term.
I've tested manually with [this submission](https://www.furaffinity.net/view/55747789), which may or may not exist later. No idea what it once was.