### PR TITLE
Fix display name parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Changelog for FAExport API, should include entries for these types of changes:
 
 Format inspired by https://keepachangelog.com/en/1.0.0/
 
+## [v2025.03.1] - 2025-03-05
+
+### Fixed
+
+- Fixed parsing of display names in comments, profile pages, and watcher lists
+- Updated tests to accommodate post tags all being lowercase now
+- Fixed note endpoint, by only removing the warning if it exists
+
 ## [v2024.08.1] - 2024-08-30
 
 ### Fixed

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -1273,7 +1273,7 @@ class Furaffinity
     users = elem.css("##{selector} a").map do |user|
       link = fa_url(user["href"][1..-1])
       {
-        name: user.at_css(".artist_name").content.strip,
+        name: user.at_css(".c-usernameBlockSimple__displayName").content.strip,
         profile_name: last_path(link),
         link: link
       }

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -534,7 +534,7 @@ class Furaffinity
 
     {
       id: nil,
-      name: html.at_css(".addpad.lead b").content.strip[1..-1],
+      name: html.at_css(".addpad.lead .c-usernameBlock__displayName").content.strip[1..-1],
       profile: fa_url(profile),
       account_type: html.at_css(".addpad.lead").content[/\((.+?)\)/, 1].strip,
       avatar: "https:#{html.at_css("td.addpad img")["src"]}",

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -566,7 +566,7 @@ class Furaffinity
     url = "watchlist/#{mode}/#{escape(name)}/#{page}/"
     html = fetch(url)
 
-    html.css(".c-usernameBlockSimple__displayName").map(&:content)
+    html.at_css("td.alt1").css(".c-usernameBlockSimple__displayName").map(&:content)
   end
 
   def submission(id, is_login = false)

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -1518,7 +1518,7 @@ class Furaffinity
         profile_url = comment.at_css("ul ul li a")["href"][1..-1]
         {
           id: id,
-          name: comment.at_css(".replyto-name").content.strip,
+          name: comment.at_css(".c-usernameBlock__displayName").content.strip,
           profile: fa_url(profile_url),
           profile_name: last_path(profile_url),
           avatar: "https:#{comment.at_css(".icon img")["src"]}",

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -1136,7 +1136,11 @@ class Furaffinity
     profile = is_inbound ? note_from : note_to
     date = pick_date(note_table.at_css("span.popup_date"))
     description = note_table.at_css("td.text")
-    description.at_css(".noteWarningMessage").unlink # Remove the warning message from the description block
+    # Remove the warning message from the description block if it exists
+    note_warning = description.at_css(".noteWarningMessage")
+    unless note_warning.nil?
+      note_warning.unlink
+    end
     desc_split = description.inner_html.split("—————————")
     name = profile&.content
     if profile.nil?

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -566,7 +566,7 @@ class Furaffinity
     url = "watchlist/#{mode}/#{escape(name)}/#{page}/"
     html = fetch(url)
 
-    html.css(".artist_name").map(&:content)
+    html.css(".c-usernameBlockSimple__displayName").map(&:content)
   end
 
   def submission(id, is_login = false)

--- a/lib/faexport/scraper.rb
+++ b/lib/faexport/scraper.rb
@@ -534,7 +534,7 @@ class Furaffinity
 
     {
       id: nil,
-      name: html.at_css(".addpad.lead .c-usernameBlock__displayName").content.strip[1..-1],
+      name: html.at_css(".addpad.lead .c-usernameBlock__displayName").content.strip,
       profile: fa_url(profile),
       account_type: html.at_css(".addpad.lead").content[/\((.+?)\)/, 1].strip,
       avatar: "https:#{html.at_css("td.addpad img")["src"]}",

--- a/tests/integration/fa_parsing_spec.rb
+++ b/tests/integration/fa_parsing_spec.rb
@@ -568,8 +568,8 @@ describe "FA parser" do
       expect(sub[:rating]).not_to be_blank
       expect(sub[:keywords]).to be_instance_of Array
       expect(sub[:keywords]).not_to be_empty
-      expect(sub[:keywords]).to include("BLEEP")
-      expect(sub[:keywords]).to include("BLORP")
+      expect(sub[:keywords]).to include("bleep")
+      expect(sub[:keywords]).to include("blorp")
     end
 
     it "handles flash files correctly" do
@@ -601,7 +601,7 @@ describe "FA parser" do
       expect(sub[:keywords]).to be_instance_of Array
       expect(sub[:keywords]).not_to be_empty
       expect(sub[:keywords]).to include("dog")
-      expect(sub[:keywords]).to include("DDR")
+      expect(sub[:keywords]).to include("ddr")
     end
 
     it "handles poetry submissions correctly" do
@@ -632,7 +632,7 @@ describe "FA parser" do
       expect(sub[:rating]).not_to be_blank
       expect(sub[:keywords]).to be_instance_of Array
       expect(sub[:keywords]).not_to be_empty
-      expect(sub[:keywords]).to include("Love")
+      expect(sub[:keywords]).to include("love")
       expect(sub[:keywords]).to include("mind")
     end
 


### PR DESCRIPTION
FA recently added display names: 
https://www.furaffinity.net/journal/11085097
Which broke quite a bit of parsing in the API. Particularly profile pages and such.

But this should make parsing more stable in future, I suspect!

Fixed that, updated a test which didn't know keywords are now enforced lowercase, and fixed stripping warning messages from notes